### PR TITLE
Replace Saru RNG

### DIFF
--- a/azplugins/DPDEvaluatorGeneralWeight.h
+++ b/azplugins/DPDEvaluatorGeneralWeight.h
@@ -12,7 +12,8 @@
 #define AZPLUGINS_DPD_EVALUATOR_GENERAL_WEIGHT_H_
 
 #include "hoomd/HOOMDMath.h"
-#include "hoomd/Saru.h"
+#include "hoomd/RandomNumbers.h"
+#include "RNGIdentifiers.h"
 
 #ifdef NVCC
 #define DEVICE __device__
@@ -195,10 +196,9 @@ class DPDEvaluatorGeneralWeight
                    m_oj = m_j;
                    }
 
-                hoomd::detail::Saru rng(m_oi, m_oj, m_seed + m_timestep);
-
                 // Generate a single random number
-                Scalar alpha = rng.s<Scalar>(-1,1);
+                hoomd::RandomGenerator rng(azplugins::RNGIdentifier::DPDEvaluatorGeneralWeight, m_seed, m_oi, m_oj, m_timestep);
+                Scalar alpha = hoomd::UniformDistribution<Scalar>(-1,1)(rng);
 
                 // conservative dpd
                 force_divr = a*(rinv - rcutinv);

--- a/azplugins/ParticleEvaporator.cc
+++ b/azplugins/ParticleEvaporator.cc
@@ -222,7 +222,7 @@ void ParticleEvaporator::makeAllPicks(unsigned int timestep, unsigned int N_pick
     m_all_picks.resize(N_mark_total);
     std::iota(m_all_picks.begin(), m_all_picks.end(), 0);
 
-    hoomd::RandomGenerator rng(azplugins::RNGIdentifiers::ParticleEvaporator, m_seed, timestep);
+    hoomd::RandomGenerator rng(azplugins::RNGIdentifier::ParticleEvaporator, m_seed, timestep);
 
     // random shuffle (fisher-yates) to get picks, seeded the same across all ranks
     auto begin = m_all_picks.begin();

--- a/azplugins/ParticleEvaporator.h
+++ b/azplugins/ParticleEvaporator.h
@@ -16,7 +16,6 @@
 #endif
 
 #include "TypeUpdater.h"
-#include <random>
 
 namespace azplugins
 {
@@ -89,11 +88,10 @@ class PYBIND11_EXPORT ParticleEvaporator : public TypeUpdater
         virtual void applyPicks();
 
     private:
-        std::mt19937 m_rng; //!< Mersenne-Twister random number generator for evaporating
         std::vector<unsigned int> m_all_picks;  //!< All picked particles
 
         //! Make a random pick of particles across all ranks
-        void makeAllPicks(unsigned int N_pick, unsigned N_mark_total);
+        void makeAllPicks(unsigned int timestep, unsigned int N_pick, unsigned N_mark_total);
     };
 
 namespace detail

--- a/azplugins/RNGIdentifiers.h
+++ b/azplugins/RNGIdentifiers.h
@@ -20,6 +20,8 @@ struct RNGIdentifier
     static const uint32_t DPDEvaluatorGeneralWeight = 0x4a84f5d1;
     static const uint32_t TwoStepBrownianFlow = 0x431287fe;
     static const uint32_t TwoStepLangevinFlow = 0x89abcdee;
+
+    static const uint32_t ParticleEvaporator = 0x3eb8536f;
     };
 
 } // end namespace azplugins

--- a/azplugins/RNGIdentifiers.h
+++ b/azplugins/RNGIdentifiers.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file RNGIdentifier.h
+ * \brief Identifiers for random123 generator.
+ */
+
+#ifndef AZPLUGINS_RNG_IDENTIFIERS_H_
+#define AZPLUGINS_RNG_IDENTIFIERS_H_
+
+namespace azplugins
+{
+
+struct RNGIdentifier
+    {
+    // hoomd's identifiers, changed by +/- 1
+    static const uint32_t DPDEvaluatorGeneralWeight = 0x4a84f5d1;
+    static const uint32_t TwoStepBrownianFlow = 0x431287fe;
+    static const uint32_t TwoStepLangevinFlow = 0x89abcdee;
+    };
+
+} // end namespace azplugins
+
+#endif // AZPLUGINS_RNG_IDENTIFIERS_H_

--- a/azplugins/TwoStepBrownianFlow.h
+++ b/azplugins/TwoStepBrownianFlow.h
@@ -150,7 +150,7 @@ void TwoStepBrownianFlow<FlowField>::integrateStepOne(unsigned int timestep)
             coeff = Scalar(0.0);
 
         // draw random force
-        hoomd::RandomGenerator(azplugins::RNGIdentifier::TwoStepBrownianFlow, m_seed, h_tag.data[idx], timestep);
+        hoomd::RandomGenerator rng(azplugins::RNGIdentifier::TwoStepBrownianFlow, m_seed, h_tag.data[idx], timestep);
         hoomd::UniformDistribution<Scalar> uniform(-coeff, coeff);
         const Scalar3 random_force = make_scalar3(uniform(rng), uniform(rng), uniform(rng));
 

--- a/azplugins/TwoStepBrownianFlowGPU.cuh
+++ b/azplugins/TwoStepBrownianFlowGPU.cuh
@@ -105,7 +105,7 @@ __global__ void brownian_flow(Scalar4 *d_pos,
         coeff = Scalar(0.0);
 
     // draw random force
-    hoomd::RandomGenerator(azplugins::RNGIdentifier::TwoStepBrownianFlow, seed, d_tag[idx], timestep);
+    hoomd::RandomGenerator rng(azplugins::RNGIdentifier::TwoStepBrownianFlow, seed, d_tag[idx], timestep);
     hoomd::UniformDistribution<Scalar> uniform(-coeff, coeff);
     const Scalar3 random_force = make_scalar3(uniform(rng), uniform(rng), uniform(rng));
 

--- a/azplugins/TwoStepLangevinFlow.h
+++ b/azplugins/TwoStepLangevinFlow.h
@@ -193,7 +193,7 @@ void TwoStepLangevinFlow<FlowField>::integrateStepTwo(unsigned int timestep)
         Scalar coeff = fast::sqrt(Scalar(6.0)*gamma*currentTemp/m_deltaT);
         if (m_noiseless)
             coeff = Scalar(0.0);
-        hoomd::RandomGenerator(azplugins::RNGIdentifier::TwoStepLangevinFlow, m_seed, h_tag.data[idx], timestep);
+        hoomd::RandomGenerator rng(azplugins::RNGIdentifier::TwoStepLangevinFlow, m_seed, h_tag.data[idx], timestep);
         hoomd::UniformDistribution<Scalar> uniform(-coeff, coeff);
         const Scalar3 random = make_scalar3(uniform(rng), uniform(rng), uniform(rng));
 

--- a/azplugins/TwoStepLangevinFlow.h
+++ b/azplugins/TwoStepLangevinFlow.h
@@ -16,8 +16,10 @@
 #endif
 
 #include "hoomd/md/TwoStepLangevinBase.h"
-#include "hoomd/Saru.h"
+#include "hoomd/RandomNumbers.h"
 #include "hoomd/extern/pybind/include/pybind11/pybind11.h"
+
+#include "RNGIdentifiers.h"
 
 namespace azplugins
 {
@@ -191,10 +193,9 @@ void TwoStepLangevinFlow<FlowField>::integrateStepTwo(unsigned int timestep)
         Scalar coeff = fast::sqrt(Scalar(6.0)*gamma*currentTemp/m_deltaT);
         if (m_noiseless)
             coeff = Scalar(0.0);
-        hoomd::detail::Saru s(h_tag.data[idx], timestep, m_seed);
-        const Scalar3 random = coeff * make_scalar3(s.s<Scalar>(-1.0, 1.0),
-                                                    s.s<Scalar>(-1.0, 1.0),
-                                                    s.s<Scalar>(-1.0, 1.0));
+        hoomd::RandomGenerator(azplugins::RNGIdentifier::TwoStepLangevinFlow, m_seed, h_tag.data[idx], timestep);
+        hoomd::UniformDistribution<Scalar> uniform(-coeff, coeff);
+        const Scalar3 random = make_scalar3(uniform(rng), uniform(rng), uniform(rng));
 
         const Scalar4 velmass = h_vel.data[idx];
         Scalar3 vel = make_scalar3(velmass.x, velmass.y, velmass.z);

--- a/azplugins/TwoStepLangevinFlowGPU.cuh
+++ b/azplugins/TwoStepLangevinFlowGPU.cuh
@@ -115,7 +115,7 @@ __global__ void langevin_flow_step2(Scalar4 *d_vel,
     Scalar coeff = fast::sqrt(Scalar(6.0) * gamma * T / dt);
     if (noiseless)
         coeff = Scalar(0.0);
-    hoomd::RandomGenerator(azplugins::RNGIdentifier::TwoStepLangevinFlow, seed, d_tag[idx], timestep);
+    hoomd::RandomGenerator rng(azplugins::RNGIdentifier::TwoStepLangevinFlow, seed, d_tag[idx], timestep);
     hoomd::UniformDistribution<Scalar> uniform(-coeff, coeff);
     const Scalar3 random = make_scalar3(uniform(rng), uniform(rng), uniform(rng));
 


### PR DESCRIPTION
Use the new random123 RNG instead of the Saru interface, which is more powerful and flexible. Also, replace one instance of stl <random> with random123 for consistency.

Resolves #11 