### PR TITLE
Silence warnings in CMake 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,15 @@
 
 project(azplugins)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.0 FATAL_ERROR)
-cmake_policy(SET CMP0074 OLD)
 
 # set the cmake policy to enable finding LOCATION in testing, per hoomd usage
 if (CMAKE_MAJOR_VERSION VERSION_GREATER 2)
 if(COMMAND cmake_policy)
     cmake_policy(SET CMP0003 NEW)
     cmake_policy(SET CMP0042 NEW)
+    if (CMAKE_VERSION VERSION_GREATER 3.11)
+        cmake_policy(SET CMP0074 OLD)
+    endif (CMAKE_VERSION VERSION_GREATER 3.11)
 endif(COMMAND cmake_policy)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 project(azplugins)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.0 FATAL_ERROR)
+cmake_policy(SET CMP0074 OLD)
 
 # set the cmake policy to enable finding LOCATION in testing, per hoomd usage
 if (CMAKE_MAJOR_VERSION VERSION_GREATER 2)

--- a/azplugins/test/CMakeLists.txt
+++ b/azplugins/test/CMakeLists.txt
@@ -29,7 +29,7 @@ macro(compile_test TEST_EXE TEST_SRC)
     # add and link the unit test executable
     add_executable(${TEST_EXE} EXCLUDE_FROM_ALL ${TEST_SRC})
     add_dependencies(test_all ${TEST_EXE})
-    target_link_libraries(${TEST_EXE} _${COMPONENT_NAME} ${HOOMD_MD_LIB} ${HOOMD_LIBRARIES} )
+    target_link_libraries(${TEST_EXE} _${COMPONENT_NAME} ${HOOMD_MD_LIB} ${HOOMD_LIBRARIES} ${PYTHON_LIBRARIES})
     fix_cudart_rpath(${TEST_EXE})
 
     if (ENABLE_MPI)


### PR DESCRIPTION
CMake 3.12 doesn't like `find_package` using `_ROOT` variables. This forces use of the old behavior for now, as we will likely rewrite the script once HOOMD 3.0 is released anyway. It also fixes an linker error in the compiled unit tests, which were apparently missing the python library.