### PR TITLE
Slit pore bounce back integrator

### DIFF
--- a/azplugins/BounceBackGeometry.h
+++ b/azplugins/BounceBackGeometry.h
@@ -18,6 +18,11 @@
 #include "hoomd/mpcd/BoundaryCondition.h"
 #include "hoomd/mpcd/SlitGeometry.h"
 
+#if (HOOMD_VERSION_MAJOR >= 2) && (HOOMD_MINOR_VERSION >= 7)
+#define AZPLUGINS_API_INTEGRATE_SLIT_PORE
+#include "hoomd/mpcd/SlitPoreGeometry.h"
+#endif
+
 #ifndef NVCC
 #include "hoomd/extern/pybind/include/pybind11/pybind11.h"
 

--- a/azplugins/BounceBackNVEGPU.cu
+++ b/azplugins/BounceBackNVEGPU.cu
@@ -21,6 +21,12 @@ namespace gpu
 template cudaError_t nve_bounce_step_one<mpcd::detail::SlitGeometry>
     (const bounce_args_t& args, const mpcd::detail::SlitGeometry& geom);
 
+#if AZPLUGINS_API_INTEGRATE_SLIT_PORE
+//! Template instantiation of slit pore geometry streaming
+template cudaError_t nve_bounce_step_one<mpcd::detail::SlitPoreGeometry>
+    (const bounce_args_t& args, const mpcd::detail::SlitPoreGeometry& geom);
+#endif
+
 namespace kernel
 {
 //! Kernel for applying second step of velocity Verlet algorithm with bounce back

--- a/azplugins/CMakeLists.txt
+++ b/azplugins/CMakeLists.txt
@@ -87,6 +87,7 @@ set(_${COMPONENT_NAME}_cu_sources
 set(py_files
     __init__.py
     analyze.py
+    api.py
     bond.py
     dpd.py
     evaporate.py

--- a/azplugins/api.py
+++ b/azplugins/api.py
@@ -1,0 +1,59 @@
+r"""Utility methods for interfacing with the HOOMD API."""
+import hoomd
+
+def parse_version(version):
+    """Parse a version string into a tuple.
+
+    Args:
+        version (str): A version string separated by '.', like 'x.y.z'.
+
+    Returns:
+        The version as a tuple.
+
+    Examples::
+
+        >>> parse_version('1.2.3')
+        (1,2,3)
+
+    """
+    return tuple([int(x) for x in version.split('.')])
+
+def str_version(version):
+    """Stringify a version tuple.
+
+    Args:
+        version (tuple): A version tuple.
+
+    Returns:
+        The version as a string separated by '.'.
+
+    Examples::
+
+        >>> str_version((1,2,3))
+        '1.2.3'
+    """
+    return '.'.join([str(x) for x in version])
+
+available = parse_version(hoomd.__version__)
+
+def require(version):
+    r"""Decorator to require a minimum HOOMD API.
+
+    Args:
+        version (str): The minimum required version, encoded as 'x.y.z'.
+
+    If `hoomd.__version__` expands to a tuple that is less than *version*,
+    an error message is generated and an `ImportError` is raised.
+
+    """
+    # wrap the decorator
+    def wrapper(function):
+        # wrap the variable
+        def _require(*args, **kwargs):
+            _version = parse_version(version)
+            if available < _version:
+                hoomd.context.msg.error('HOOMD {} or newer is required, but {} found.\n'.format(str_version(_version), str_version(available)))
+                raise ImportError('Minimum HOOMD version not available')
+            function(*args,**kwargs)
+        return _require
+    return wrapper

--- a/azplugins/api.py
+++ b/azplugins/api.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2018-2019, Michael P. Howard
+# This file is part of the azplugins project, released under the Modified BSD License.
+
+# Maintainer: mphoward
+
 r"""Utility methods for interfacing with the HOOMD API."""
 import hoomd
 

--- a/azplugins/integrate.py
+++ b/azplugins/integrate.py
@@ -177,7 +177,7 @@ class slit_pore(_bounce_back):
     the walls are placed at :math:`z=-H` and :math:`z=+H`, and they extend from :math:`x=-L` to :math:`x=+L`
     (total length *2L*). Additional solid walls with normals in *x* prevent penetration into the regions
     above / below the plates. The plates are infinite in *y*. Outside the pore, the simulation box has full periodic
-    boundaries; it is not confined by any walls. This model hence mimics a narrow pore in, e.g., a membrane.
+    boundaries, and it is not confined by any walls. This model hence mimics a narrow pore in, e.g., a membrane.
 
     Note:
         It may be necessary to add additional 'ghost' particles near the boundaries in order to correctly enforce the

--- a/azplugins/module.cc
+++ b/azplugins/module.cc
@@ -231,7 +231,13 @@ PYBIND11_MODULE(_azplugins, m)
     azplugins::detail::export_TwoStepLangevinFlowGPU<azplugins::QuiescentFluid>(m, "LangevinQuiescentFluidGPU");
     #endif // ENABLE_CUDA
     azplugins::detail::export_BounceBackNVE<mpcd::detail::SlitGeometry>(m);
+    #if AZPLUGINS_API_INTEGRATE_SLIT_PORE
+    azplugins::detail::export_BounceBackNVE<mpcd::detail::SlitPoreGeometry>(m);
+    #endif
     #ifdef ENABLE_CUDA
     azplugins::detail::export_BounceBackNVEGPU<mpcd::detail::SlitGeometry>(m);
+    #if AZPLUGINS_API_INTEGRATE_SLIT_PORE
+    azplugins::detail::export_BounceBackNVEGPU<mpcd::detail::SlitPoreGeometry>(m);
+    #endif
     #endif // ENABLE_CUDA
     }

--- a/azplugins/test-py/CMakeLists.txt
+++ b/azplugins/test-py/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_LIST_CPU
     test_flow_parabolic
     test_flow_quiescent
     test_integrate_slit
+    test_integrate_slit_pore
     test_pair_ashbaugh
     test_pair_ashbaugh24
     test_pair_lj124
@@ -40,6 +41,7 @@ set(TEST_LIST_GPU
     test_flow_brownian
     test_flow_langevin
     test_integrate_slit
+    test_integrate_slit_pore
     test_pair_ashbaugh
     test_pair_ashbaugh24
     test_pair_lj124

--- a/azplugins/test-py/test_integrate_slit_pore.py
+++ b/azplugins/test-py/test_integrate_slit_pore.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2018-2019, Michael P. Howard
+# This file is part of the azplugins project, released under the Modified BSD License.
+
+# Maintainer: mphoward
+
+import hoomd
+from hoomd import md
+hoomd.context.initialize()
+try:
+    from hoomd import azplugins
+except ImportError:
+    import azplugins
+import unittest
+import numpy as np
+
+# unit tests for slit pore bounce back geometry
+@unittest.skipIf(azplugins.api.available < (2,7,0), "HOOMD 2.7.0 required")
+class integrate_slit_pore_tests(unittest.TestCase):
+    """ Unit tests for slit pore integrator.
+
+    Most of the physics is already tested in hoomd.mpcd, so
+    these unit tests are focused on the python API.
+
+    """
+    def setUp(self):
+        # establish the simulation context
+        hoomd.context.initialize()
+
+        # set the decomposition in z for mpi builds
+        if hoomd.comm.get_num_ranks() > 1:
+            hoomd.comm.decomposition(nz=2)
+
+        # default testing configuration
+        snap = hoomd.data.make_snapshot(N=2, box=hoomd.data.boxdim(L=10.))
+        if hoomd.comm.get_rank() == 0:
+            snap.particles.position[:] = [[4.95,-4.95,3.85],[0.,0.,-3.8]]
+            snap.particles.velocity[:] = [[1.,-1.,1.],[-1.,-1.,-1.]]
+            snap.particles.mass[:] = [1.,2.]
+        self.s = hoomd.init.read_snapshot(snap)
+        self.group = hoomd.group.all()
+
+        md.integrate.mode_standard(dt=0.1)
+
+    # test creation can happen (with all parameters set)
+    def test_create(self):
+        azplugins.integrate.slit_pore(group=self.group, H=4., L=2., boundary="no_slip")
+
+    # test for setting parameters
+    def test_set_params(self):
+        slit_pore = azplugins.integrate.slit_pore(group=self.group, H=4., L=2.)
+        self.assertAlmostEqual(slit_pore.H, 4.)
+        self.assertAlmostEqual(slit_pore.L, 2.)
+        self.assertEqual(slit_pore.boundary, "no_slip")
+        self.assertAlmostEqual(slit_pore.cpp_method.geometry.getH(), 4.)
+        self.assertAlmostEqual(slit_pore.cpp_method.geometry.getL(), 2.)
+        self.assertEqual(slit_pore.cpp_method.geometry.getBoundaryCondition(), hoomd.mpcd._mpcd.boundary.no_slip)
+
+        # change H and also ensure other parameters stay the same
+        slit_pore.set_params(H=2.)
+        self.assertAlmostEqual(slit_pore.H, 2.)
+        self.assertAlmostEqual(slit_pore.L, 2.)
+        self.assertEqual(slit_pore.boundary, "no_slip")
+        self.assertAlmostEqual(slit_pore.cpp_method.geometry.getH(), 2.)
+        self.assertAlmostEqual(slit_pore.cpp_method.geometry.getL(), 2.)
+        self.assertEqual(slit_pore.cpp_method.geometry.getBoundaryCondition(), hoomd.mpcd._mpcd.boundary.no_slip)
+
+        # change L
+        slit_pore.set_params(L=3.)
+        self.assertAlmostEqual(slit_pore.L, 3.)
+        self.assertAlmostEqual(slit_pore.cpp_method.geometry.getL(), 3.)
+
+        # change BCs
+        slit_pore.set_params(boundary="slip")
+        self.assertEqual(slit_pore.boundary, "slip")
+        self.assertEqual(slit_pore.cpp_method.geometry.getBoundaryCondition(), hoomd.mpcd._mpcd.boundary.slip)
+
+    # test for invalid boundary conditions being set
+    def test_bad_boundary(self):
+        slit_pore = azplugins.integrate.slit_pore(group=self.group, H=4., L=2.)
+        slit_pore.set_params(boundary="no_slip")
+        slit_pore.set_params(boundary="slip")
+
+        with self.assertRaises(ValueError):
+            slit_pore.set_params(boundary="invalid")
+
+    def tearDown(self):
+        del self.s, self.group
+
+if __name__ == '__main__':
+    unittest.main(argv = ['test.py', '-v'])


### PR DESCRIPTION
This PR adds support for the NVE bounce back integrator in the slit pore geometry that will be added to HOOMD 2.7 (https://github.com/glotzerlab/hoomd-blue/issues/440). As such, it shouldn't be merged until that is released, and we will also need to start testing that version of hoomd in CI.

To try to start guaranteeing compatibility with different HOOMD APIs (#10), this PR also implements an experimental decorator interface. The idea is that on the python side, we will decorate classes with things like
```
@api.require('2.7.0')
class slit_pore(...):
```
which will do an automatic check against the tagged version of HOOMD, and raise an error if the minimum is not met. On the C++ side, we can do conditional compilation. There are preprocessor defines for `HOOMD_VERSION_MAJOR` and `HOOMD_VERSION_MINOR`. I propose letting the azplugins headers define their own API keys that mimic the python command naming as needed:
```
#if (HOOMD_VERSION_MAJOR >= 2) && (HOOMD_VERSION_MINOR >= 7)
#define AZPLUGINS_API_INTEGRATE_SLIT_PORE
#endif
```
For now, I did this in the header, but we could also create some sort of `api.h` that lets us define all of these in one place. The only potential issue with this is when `*.cc` and `*.h` files should be completely skipped (and not installed), which is a CMake issue.

The decorator api needs testing and I might change some things as I try using this in production, but opening this now anyway.