### PR TITLE
Implicit droplet evaporator

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -7,7 +7,7 @@
 - Original software design and plugin frameworks.
 - `analyze.rdf`: Radial distribution function calculator.
 - `dpd.general`: Generalized DPD pair potential.
-- `evaporate.implicit`: Moving harmonic potential to simulate drying.
+- `evaporate.implicit`: Moving harmonic potential to simulate drying in films and droplets.
 - `evaporate.particles`: Particle type changer to simulate explicit drying.
 - `flow.brownian` / `flow.langevin` and imposed flow framework.
 - `integrate.slit` and bounce-back integrator framework.

--- a/azplugins/CMakeLists.txt
+++ b/azplugins/CMakeLists.txt
@@ -36,6 +36,8 @@ set(_${COMPONENT_NAME}_sources
     module.cc
     BounceBackGeometry.cc
     ImplicitEvaporator.cc
+    ImplicitDropletEvaporator.cc
+    ImplicitPlaneEvaporator.cc
     OrientationRestraintCompute.cc
     ParticleEvaporator.cc
     PositionRestraintCompute.cc
@@ -48,6 +50,8 @@ set(_${COMPONENT_NAME}_sources
 if(ENABLE_CUDA)
 list(APPEND _${COMPONENT_NAME}_sources
     ImplicitEvaporatorGPU.cc
+    ImplicitDropletEvaporatorGPU.cc
+    ImplicitPlaneEvaporatorGPU.cc
     OrientationRestraintComputeGPU.cc
     ParticleEvaporatorGPU.cc
     PositionRestraintComputeGPU.cc
@@ -63,7 +67,8 @@ set(_${COMPONENT_NAME}_cu_sources
     BondPotentials.cu
     BounceBackNVEGPU.cu
     DPDPotentials.cu
-    ImplicitEvaporatorGPU.cu
+    ImplicitDropletEvaporatorGPU.cu
+    ImplicitPlaneEvaporatorGPU.cu
     OrientationRestraintComputeGPU.cu
     PairPotentialAshbaugh.cu
     PairPotentialAshbaugh24.cu

--- a/azplugins/ImplicitDropletEvaporator.cc
+++ b/azplugins/ImplicitDropletEvaporator.cc
@@ -1,0 +1,111 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file ImplicitDropletEvaporator.cc
+ * \brief Definition of ImplicitDropletEvaporator
+ */
+
+#include "ImplicitDropletEvaporator.h"
+
+namespace azplugins
+{
+/*!
+ * \param sysdef System definition
+ * \param interf Position of the interface
+ */
+ImplicitDropletEvaporator::ImplicitDropletEvaporator(std::shared_ptr<SystemDefinition> sysdef,
+                                                     std::shared_ptr<Variant> interf)
+        : ImplicitEvaporator(sysdef, interf)
+    {
+    m_exec_conf->msg->notice(5) << "Constructing ImplicitDropletEvaporator" << std::endl;
+    }
+
+ImplicitDropletEvaporator::~ImplicitDropletEvaporator()
+    {
+    m_exec_conf->msg->notice(5) << "Destroying ImplicitDropletEvaporator" << std::endl;
+    }
+
+/*!
+ * \param timestep Current timestep
+ */
+void ImplicitDropletEvaporator::computeForces(unsigned int timestep)
+    {
+    ImplicitEvaporator::computeForces(timestep);
+
+    // check radius fits in box
+    const Scalar interf_origin = m_interf->getValue(timestep);
+        {
+        const BoxDim& box = m_pdata->getGlobalBox();
+        const Scalar3 hi = box.getHi();
+        const Scalar3 lo = box.getLo();
+        if (interf_origin > hi.x || interf_origin < lo.x ||
+            interf_origin > hi.y || interf_origin < lo.y ||
+            interf_origin > hi.z || interf_origin < lo.z)
+            {
+            m_exec_conf->msg->error() << "ImplicitDropletEvaporator interface must be inside the simulation box" << std::endl;
+            throw std::runtime_error("ImplicitDropletEvaporator interface must be inside the simulation box");
+            }
+        }
+
+    ArrayHandle<Scalar4> h_force(m_force, access_location::host, access_mode::overwrite);
+    ArrayHandle<Scalar> h_virial(m_virial, access_location::host, access_mode::overwrite);
+    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
+    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+
+    ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host, access_mode::read);
+    ArrayHandle<Scalar4> h_params(m_params, access_location::host, access_mode::read);
+    for (unsigned int idx = 0; idx < m_pdata->getN(); ++idx)
+        {
+        const Scalar4 postype_i = h_pos.data[idx];
+        const Scalar3 pos_i = make_scalar3(postype_i.x, postype_i.y, postype_i.z);
+        const unsigned int type_i = __scalar_as_int(postype_i.w);
+
+        const Scalar4 params = h_params.data[type_i];
+        const Scalar k = params.x;
+        const Scalar offset = params.y;
+        const Scalar g = params.z;
+        const Scalar cutoff = params.w;
+        // continue if interaction is off
+        if (cutoff < Scalar(0.0)) continue;
+
+        // get distances and direction of force
+        const Scalar r_i = fast::sqrt(dot(pos_i,pos_i));
+        const Scalar dr = r_i - (interf_origin + offset);
+        if (!(r_i > Scalar(0.0)) || dr < Scalar(0.0)) continue;
+        const Scalar3 rhat = pos_i/r_i;
+
+        Scalar3 f;
+        Scalar e;
+        if (dr < cutoff) // harmonic
+            {
+            f = -k * dr * rhat;
+            e = Scalar(0.5) * k * (dr * dr); // (k/2) dr^2
+            }
+        else // linear
+            {
+            f = -g * rhat;
+            e = Scalar(0.5) * k * cutoff * cutoff + g * (dr - cutoff);
+            }
+
+        h_force.data[idx] = make_scalar4(f.x, f.y, f.z, e);
+        }
+    }
+
+namespace detail
+{
+/*!
+ * \param m Python module to export to
+ */
+void export_ImplicitDropletEvaporator(pybind11::module& m)
+    {
+    namespace py = pybind11;
+    py::class_<ImplicitDropletEvaporator,std::shared_ptr<ImplicitDropletEvaporator>>(m, "ImplicitDropletEvaporator", py::base<ImplicitEvaporator>())
+        .def(py::init<std::shared_ptr<SystemDefinition>,std::shared_ptr<Variant>>());
+    ;
+    }
+} // end namespace detail
+
+} // end namespace azplugins

--- a/azplugins/ImplicitDropletEvaporator.h
+++ b/azplugins/ImplicitDropletEvaporator.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file ImplicitDropletEvaporator.h
+ * \brief Declaration of ImplicitDropletEvaporator
+ */
+
+#ifndef AZPLUGINS_IMPLICIT_DROPLET_EVAPORATOR_H_
+#define AZPLUGINS_IMPLICIT_DROPLET_EVAPORATOR_H_
+
+#ifdef NVCC
+#error This header cannot be compiled by nvcc
+#endif
+
+#include "ImplicitEvaporator.h"
+
+#include "hoomd/extern/pybind/include/pybind11/pybind11.h"
+
+namespace azplugins
+{
+
+//! Implicit solvent evaporator in a spherical (droplet) geometry
+/*
+ * The interface normal is that of a sphere, and its origin is (0,0,0).
+ */
+class PYBIND11_EXPORT ImplicitDropletEvaporator : public ImplicitEvaporator
+    {
+    public:
+        //! Constructor
+        ImplicitDropletEvaporator(std::shared_ptr<SystemDefinition> sysdef,
+                                  std::shared_ptr<Variant> interf);
+
+        virtual ~ImplicitDropletEvaporator();
+
+    protected:
+        //! Implements the force calculation
+        virtual void computeForces(unsigned int timestep);
+    };
+
+namespace detail
+{
+//! Exports the ImplicitDropletEvaporator to python
+void export_ImplicitDropletEvaporator(pybind11::module& m);
+} // end namespace detail
+
+} // end namespace azplugins
+
+#endif // AZPLUGINS_IMPLICIT_DROPLET_EVAPORATOR_H_

--- a/azplugins/ImplicitDropletEvaporatorGPU.cc
+++ b/azplugins/ImplicitDropletEvaporatorGPU.cc
@@ -1,0 +1,87 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file ImplicitDropletEvaporatorGPU.cc
+ * \brief Definition of ImplicitDropletEvaporatorGPU
+ */
+
+#include "ImplicitDropletEvaporatorGPU.h"
+#include "ImplicitDropletEvaporatorGPU.cuh"
+
+namespace azplugins
+{
+
+/*!
+ * \param sysdef System definition
+ * \param interf Position of the interface
+ */
+ImplicitDropletEvaporatorGPU::ImplicitDropletEvaporatorGPU(std::shared_ptr<SystemDefinition> sysdef,
+                                                           std::shared_ptr<Variant> interf)
+        : ImplicitEvaporatorGPU(sysdef, interf)
+    {
+    m_exec_conf->msg->notice(5) << "Constructing ImplicitDropletEvaporatorGPU" << std::endl;
+    }
+
+ImplicitDropletEvaporatorGPU::~ImplicitDropletEvaporatorGPU()
+    {
+    m_exec_conf->msg->notice(5) << "Destroying ImplicitDropletEvaporatorGPU" << std::endl;
+    }
+
+/*!
+ * \param timestep Current timestep
+ */
+void ImplicitDropletEvaporatorGPU::computeForces(unsigned int timestep)
+    {
+    ImplicitEvaporatorGPU::computeForces(timestep);
+
+    // check radius fits in box
+    const Scalar interf_origin = m_interf->getValue(timestep);
+        {
+        const BoxDim& box = m_pdata->getGlobalBox();
+        const Scalar3 hi = box.getHi();
+        const Scalar3 lo = box.getLo();
+        if (interf_origin > hi.x || interf_origin < lo.x ||
+            interf_origin > hi.y || interf_origin < lo.y ||
+            interf_origin > hi.z || interf_origin < lo.z)
+            {
+            m_exec_conf->msg->error() << "ImplicitDropletEvaporator interface must be inside the simulation box" << std::endl;
+            throw std::runtime_error("ImplicitDropletEvaporator interface must be inside the simulation box");
+            }
+        }
+
+    ArrayHandle<Scalar4> d_force(m_force, access_location::device, access_mode::overwrite);
+    ArrayHandle<Scalar> d_virial(m_virial, access_location::device, access_mode::overwrite);
+    ArrayHandle<Scalar4> d_pos(m_pdata->getPositions(), access_location::device, access_mode::read);
+    ArrayHandle<Scalar4> d_params(m_params, access_location::device, access_mode::read);
+
+    m_tuner->begin();
+    gpu::compute_implicit_evap_droplet_force(d_force.data,
+                                             d_virial.data,
+                                             d_pos.data,
+                                             d_params.data,
+                                             interf_origin,
+                                             m_pdata->getN(),
+                                             m_pdata->getNTypes(),
+                                             m_tuner->getParam());
+    if (m_exec_conf->isCUDAErrorCheckingEnabled()) CHECK_CUDA_ERROR();
+    m_tuner->end();
+    }
+
+namespace detail
+{
+/*!
+ * \param m Python module to export to
+ */
+void export_ImplicitDropletEvaporatorGPU(pybind11::module& m)
+    {
+    namespace py = pybind11;
+    py::class_<ImplicitDropletEvaporatorGPU,std::shared_ptr<ImplicitDropletEvaporatorGPU> >(m, "ImplicitDropletEvaporatorGPU", py::base<ImplicitEvaporatorGPU>())
+        .def(py::init<std::shared_ptr<SystemDefinition>,std::shared_ptr<Variant>>())
+    ;
+    }
+} // end namespace detail
+
+} // end namespace azplugins

--- a/azplugins/ImplicitDropletEvaporatorGPU.cu
+++ b/azplugins/ImplicitDropletEvaporatorGPU.cu
@@ -1,0 +1,142 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file ImplicitDropletEvaporatorGPU.cu
+ * \brief Definition of kernel drivers and kernels for ImplicitDropletEvaporatorGPU
+ */
+
+#include "ImplicitDropletEvaporatorGPU.cuh"
+
+namespace azplugins
+{
+namespace gpu
+{
+namespace kernel
+{
+
+/*!
+ * \param d_force Particle forces
+ * \param d_virial Particle virial
+ * \param d_pos Particle positions
+ * \param d_params Per-type parameters
+ * \param interf_origin Position of interface origin
+ * \param N Number of particles
+ * \param ntypes Number of types
+ *
+ * Using one thread per particle, the force of the harmonic potential is computed
+ * per-particle. The per-particle-type parameters are cached into shared memory.
+ * This method does not compute the virial.
+ *
+ */
+__global__ void compute_implicit_evap_droplet_force(Scalar4 *d_force,
+                                                    Scalar *d_virial,
+                                                    const Scalar4 *d_pos,
+                                                    const Scalar4 *d_params,
+                                                    const Scalar interf_origin,
+                                                    const unsigned int N,
+                                                    const unsigned int ntypes)
+    {
+    // load per-type parameters into shared memory
+    extern __shared__ Scalar4 s_params[];
+    for (unsigned int cur_offset = 0; cur_offset < ntypes; cur_offset += blockDim.x)
+        {
+        if (cur_offset + threadIdx.x < ntypes)
+            {
+            s_params[cur_offset + threadIdx.x] = d_params[cur_offset + threadIdx.x];
+            }
+        }
+    __syncthreads();
+
+    // one thread per particle
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= N)
+        return;
+
+    const Scalar4 postype_i = d_pos[idx];
+    const Scalar3 pos_i = make_scalar3(postype_i.x, postype_i.y, postype_i.z);
+    const unsigned int type_i = __scalar_as_int(postype_i.w);
+
+    const Scalar4 params = s_params[type_i];
+    const Scalar k = params.x;
+    const Scalar offset = params.y;
+    const Scalar g = params.z;
+    const Scalar cutoff = params.w;
+    // exit if interaction is off
+    if (cutoff < Scalar(0.0)) return;
+
+    // get distances and direction of force
+    const Scalar r_i = fast::sqrt(dot(pos_i,pos_i));
+    const Scalar dr = r_i - (interf_origin + offset);
+    if (!(r_i > Scalar(0.0)) || dr < Scalar(0.0)) return;
+    const Scalar3 rhat = pos_i/r_i;
+
+    Scalar3 f;
+    Scalar e;
+    if (dr < cutoff) // harmonic
+        {
+        f = -k * dr * rhat;
+        e = Scalar(0.5) * k * (dr * dr); // (k/2) dr^2
+        }
+    else // linear
+        {
+        f = -g * rhat;
+        e = Scalar(0.5) * k * cutoff * cutoff + g * (dr - cutoff);
+        }
+
+    d_force[idx] = make_scalar4(f.x, f.y, f.z, e);
+    }
+} // end namespace kernel
+
+/*!
+ * \param d_force Particle forces
+ * \param d_virial Particle virial
+ * \param d_pos Particle positions
+ * \param d_params Per-type parameters
+ * \param interf_origin Position of interface origin
+ * \param N Number of particles
+ * \param ntypes Number of types
+ * \param block_size Number of threads per block
+ *
+ * This kernel driver is a wrapper around kernel::compute_implicit_evap_force.
+ * The forces and virial are both set to zero before calculation.
+ */
+cudaError_t compute_implicit_evap_droplet_force(Scalar4 *d_force,
+                                                Scalar *d_virial,
+                                                const Scalar4 *d_pos,
+                                                const Scalar4 *d_params,
+                                                const Scalar interf_origin,
+                                                const unsigned int N,
+                                                const unsigned int ntypes,
+                                                const unsigned int block_size)
+    {
+    // zero the force and virial datasets before launch
+    cudaMemset(d_force, 0, sizeof(Scalar4)*N);
+    cudaMemset(d_virial, 0, 6*sizeof(Scalar)*N);
+
+    static unsigned int max_block_size = UINT_MAX;
+    if (max_block_size == UINT_MAX)
+        {
+        cudaFuncAttributes attr;
+        cudaFuncGetAttributes(&attr, (const void*)kernel::compute_implicit_evap_droplet_force);
+        max_block_size = attr.maxThreadsPerBlock;
+        }
+
+    unsigned int run_block_size = min(block_size, max_block_size);
+    unsigned int shared_size = sizeof(Scalar4) * ntypes;
+
+    dim3 grid(N / run_block_size + 1);
+    kernel::compute_implicit_evap_droplet_force<<<grid, run_block_size, shared_size>>>(d_force,
+                                                                                       d_virial,
+                                                                                       d_pos,
+                                                                                       d_params,
+                                                                                       interf_origin,
+                                                                                       N,
+                                                                                       ntypes);
+    return cudaSuccess;
+    }
+
+} // end namespace gpu
+} // end namespace azplugins

--- a/azplugins/ImplicitDropletEvaporatorGPU.cuh
+++ b/azplugins/ImplicitDropletEvaporatorGPU.cuh
@@ -1,0 +1,35 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file ImplicitDropletEvaporatorGPU.cuh
+ * \brief Declaration of kernel drivers for ImplicitDropletEvaporatorGPU
+ */
+
+#ifndef AZPLUGINS_IMPLICIT_DROPLET_EVAPORATOR_GPU_CUH_
+#define AZPLUGINS_IMPLICIT_DROPLET_EVAPORATOR_GPU_CUH_
+
+#include <cuda_runtime.h>
+#include "hoomd/HOOMDMath.h"
+
+namespace azplugins
+{
+namespace gpu
+{
+
+//! Kernel driver to evaluate ImplicitDropletEvaporatorGPU force
+cudaError_t compute_implicit_evap_droplet_force(Scalar4 *d_force,
+                                                Scalar *d_virial,
+                                                const Scalar4 *d_pos,
+                                                const Scalar4 *d_params,
+                                                const Scalar interf_origin,
+                                                const unsigned int N,
+                                                const unsigned int ntypes,
+                                                const unsigned int block_size);
+
+} // end namespace gpu
+} // end namespace azplugins
+
+#endif // AZPLUGINS_IMPLICIT_DROPLET_EVAPORATOR_GPU_CUH_

--- a/azplugins/ImplicitDropletEvaporatorGPU.h
+++ b/azplugins/ImplicitDropletEvaporatorGPU.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file ImplicitDropletEvaporatorGPU.h
+ * \brief Declaration of ImplicitDropletEvaporatorGPU
+ */
+
+#ifndef AZPLUGINS_IMPLICIT_DROPLET_EVAPORATOR_GPU_H_
+#define AZPLUGINS_IMPLICIT_DROPLET_EVAPORATOR_GPU_H_
+
+#ifdef NVCC
+#error This header cannot be compiled by nvcc
+#endif
+
+#include "ImplicitEvaporatorGPU.h"
+
+namespace azplugins
+{
+
+//! Implicit solvent evaporator in a spherical (droplet) geometry (on the GPU)
+class PYBIND11_EXPORT ImplicitDropletEvaporatorGPU : public ImplicitEvaporatorGPU
+    {
+    public:
+        //! Constructor
+        ImplicitDropletEvaporatorGPU(std::shared_ptr<SystemDefinition> sysdef,
+                                   std::shared_ptr<Variant> interf);
+
+        //! Destructor
+        virtual ~ImplicitDropletEvaporatorGPU();
+
+    protected:
+        //! Implements the force calculation
+        virtual void computeForces(unsigned int timestep);
+    };
+
+namespace detail
+{
+//! Exports the ImplicitDropletEvaporatorGPU to python
+void export_ImplicitDropletEvaporatorGPU(pybind11::module& m);
+} // end namespace detail
+
+} // end namespace azplugins
+
+#endif // AZPLUGINS_IMPLICIT_DROPLET_EVAPORATOR_GPU_H_

--- a/azplugins/ImplicitEvaporator.cc
+++ b/azplugins/ImplicitEvaporator.cc
@@ -20,8 +20,6 @@ ImplicitEvaporator::ImplicitEvaporator(std::shared_ptr<SystemDefinition> sysdef,
                                        std::shared_ptr<Variant> interf)
         : ForceCompute(sysdef), m_interf(interf), m_has_warned(false)
     {
-    m_exec_conf->msg->notice(5) << "Constructing ImplicitEvaporator" << std::endl;
-
     // allocate memory per type for parameters
     GPUArray<Scalar4> params(m_pdata->getNTypes(), m_exec_conf);
     m_params.swap(params);
@@ -32,66 +30,22 @@ ImplicitEvaporator::ImplicitEvaporator(std::shared_ptr<SystemDefinition> sysdef,
 
 ImplicitEvaporator::~ImplicitEvaporator()
     {
-    m_exec_conf->msg->notice(5) << "Destroying ImplicitEvaporator" << std::endl;
-
     m_pdata->getNumTypesChangeSignal().disconnect<ImplicitEvaporator, &ImplicitEvaporator::reallocateParams>(this);
     }
 
 /*!
  * \param timestep Current timestep
+ *
+ * This method only checks for warnings about the virial.
+ * Deriving classes should implement the actual force compute method.
  */
 void ImplicitEvaporator::computeForces(unsigned int timestep)
     {
-    PDataFlags flags = this->m_pdata->getFlags();
+    PDataFlags flags = m_pdata->getFlags();
     if (!m_has_warned && (flags[pdata_flag::pressure_tensor] || flags[pdata_flag::isotropic_virial]))
         {
-        m_exec_conf->msg->warning() << "ImplicitEvaporator does not compute its virial contribution, pressure may be inaccurate" << std::endl;
+        m_exec_conf->msg->warning() << "ImplicitPlaneEvaporator does not compute its virial contribution, pressure may be inaccurate" << std::endl;
         m_has_warned = true;
-        }
-
-    const BoxDim& box = m_pdata->getGlobalBox();
-    const Scalar interf_origin = m_interf->getValue(timestep);
-    if (interf_origin > box.getHi().z || interf_origin < box.getLo().z)
-        {
-        m_exec_conf->msg->error() << "ImplicitEvaporator interface must be inside the simulation box" << std::endl;
-        throw std::runtime_error("ImplicitEvaporator interface must be inside the simulation box");
-        }
-
-    ArrayHandle<Scalar4> h_force(m_force, access_location::host, access_mode::overwrite);
-    ArrayHandle<Scalar> h_virial(m_virial, access_location::host, access_mode::overwrite);
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
-
-    ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host, access_mode::read);
-    ArrayHandle<Scalar4> h_params(m_params, access_location::host, access_mode::read);
-    for (unsigned int idx = 0; idx < m_pdata->getN(); ++idx)
-        {
-        const Scalar4 postype_i = h_pos.data[idx];
-        const Scalar z_i = postype_i.z;
-        const unsigned int type_i = __scalar_as_int(postype_i.w);
-
-        const Scalar4 params = h_params.data[type_i];
-        const Scalar k = params.x;
-        const Scalar offset = params.y;
-        const Scalar g = params.z;
-        const Scalar cutoff = params.w;
-
-        const Scalar dz = z_i - (interf_origin + offset);
-        if (cutoff < Scalar(0.0) || dz < Scalar(0.0)) continue;
-
-        Scalar fz(0.0), e(0.0);
-        if (dz < cutoff) // harmonic
-            {
-            fz = -k * dz;
-            e = Scalar(-0.5) * fz * dz; // (k/2) dz^2
-            }
-        else // linear
-            {
-            fz = -g;
-            e = Scalar(0.5) * k * cutoff * cutoff + g * (dz - cutoff);
-            }
-
-        h_force.data[idx] = make_scalar4(0.0, 0.0, fz, e);
         }
     }
 
@@ -103,10 +57,9 @@ namespace detail
 void export_ImplicitEvaporator(pybind11::module& m)
     {
     namespace py = pybind11;
-    py::class_< ImplicitEvaporator, std::shared_ptr<ImplicitEvaporator> >(m, "ImplicitEvaporator", py::base<ForceCompute>())
-        .def(py::init< std::shared_ptr<SystemDefinition>, std::shared_ptr<Variant> >())
+    py::class_<ImplicitEvaporator,std::shared_ptr<ImplicitEvaporator>>(m, "ImplicitEvaporator", py::base<ForceCompute>())
+        .def(py::init< std::shared_ptr<SystemDefinition>, std::shared_ptr<Variant>>())
         .def("setParams", &ImplicitEvaporator::setParams);
-    ;
     }
 } // end namespace detail
 

--- a/azplugins/ImplicitEvaporator.cc
+++ b/azplugins/ImplicitEvaporator.cc
@@ -44,7 +44,7 @@ void ImplicitEvaporator::computeForces(unsigned int timestep)
     PDataFlags flags = m_pdata->getFlags();
     if (!m_has_warned && (flags[pdata_flag::pressure_tensor] || flags[pdata_flag::isotropic_virial]))
         {
-        m_exec_conf->msg->warning() << "ImplicitPlaneEvaporator does not compute its virial contribution, pressure may be inaccurate" << std::endl;
+        m_exec_conf->msg->warning() << "ImplicitEvaporator does not compute its virial contribution, pressure may be inaccurate" << std::endl;
         m_has_warned = true;
         }
     }

--- a/azplugins/ImplicitEvaporator.h
+++ b/azplugins/ImplicitEvaporator.h
@@ -26,9 +26,7 @@ namespace azplugins
 //! Implicit solvent evaporator
 /*!
  * Implicitly models the effect of solvent evaporation as a moving interface.
- *
- * The moving interface compute acts on particles along the z direction, with
- * the interface normal defined along +z going from the liquid into the vapor phase.
+ * The moving interface compute acts on particles along the inward normal.
  * The interface potential is harmonic. It does not include an attractive
  * part (i.e., it is truncated at its minimum, and is zero for any negative
  * displacements relative to the minimum). The position of the minimum can be
@@ -52,6 +50,10 @@ namespace azplugins
  *  - \a offset (distance) - per-particle-type amount to shift \a H, default: 0.0
  *  - \f$F_g\f$ - \a g (force) - force to apply above \f$H_{\rm c}\f$
  *  - \f$\Delta\f$ - \a cutoff (distance) - sets cutoff at \f$H_{\rm c} = H + \Delta\f$
+ *
+ * The meaning of \f$z\f$ is the distance from some origin, and \f$H\f$ is the distance of
+ * the interface (e.g., a plane, sphere, etc.) from that same origin. This class doesn't
+ * actually compute anything on its own. Deriving classes should implement this geometry.
  *
  * \warning The temperature reported by ComputeThermo will likely not be accurate
  *          during evaporation because the system is out-of-equilibrium,
@@ -89,15 +91,15 @@ class PYBIND11_EXPORT ImplicitEvaporator : public ForceCompute
             }
 
     protected:
-        //! Implements the force calculation
-        virtual void computeForces(unsigned int timestep);
-
         std::shared_ptr<Variant> m_interf;      //!< Current location of the interface
         GPUArray<Scalar4> m_params;             //!< Per-type array of parameters for the potential
 
-        bool m_has_warned;  //!< Flag if a warning has been issued about the virial
+        //! Method to compute the forces
+        virtual void computeForces(unsigned int timestep);
 
     private:
+        bool m_has_warned;  //!< Flag if a warning has been issued about the virial
+
         //! Reallocate the per-type parameter arrays when the number of types changes
         void reallocateParams()
             {

--- a/azplugins/ImplicitEvaporatorGPU.cc
+++ b/azplugins/ImplicitEvaporatorGPU.cc
@@ -9,7 +9,6 @@
  */
 
 #include "ImplicitEvaporatorGPU.h"
-#include "ImplicitEvaporatorGPU.cuh"
 
 namespace azplugins
 {
@@ -25,44 +24,6 @@ ImplicitEvaporatorGPU::ImplicitEvaporatorGPU(std::shared_ptr<SystemDefinition> s
     m_tuner.reset(new Autotuner(32, 1024, 32, 5, 100000, "implicit_evap", m_exec_conf));
     }
 
-/*!
- * \param timestep Current timestep
- */
-void ImplicitEvaporatorGPU::computeForces(unsigned int timestep)
-    {
-    PDataFlags flags = this->m_pdata->getFlags();
-    if (!m_has_warned && (flags[pdata_flag::pressure_tensor] || flags[pdata_flag::isotropic_virial]))
-        {
-        m_exec_conf->msg->warning() << "ImplicitEvaporator does not compute its virial contribution, pressure may be inaccurate" << std::endl;
-        m_has_warned = true;
-        }
-
-    const BoxDim& box = m_pdata->getGlobalBox();
-    const Scalar interf_origin = m_interf->getValue(timestep);
-    if (interf_origin > box.getHi().z || interf_origin < box.getLo().z)
-        {
-        m_exec_conf->msg->error() << "ImplicitEvaporator interface must be inside the simulation box" << std::endl;
-        throw std::runtime_error("ImplicitEvaporator interface must be inside the simulation box");
-        }
-
-    ArrayHandle<Scalar4> d_force(m_force, access_location::device, access_mode::overwrite);
-    ArrayHandle<Scalar> d_virial(m_virial, access_location::device, access_mode::overwrite);
-    ArrayHandle<Scalar4> d_pos(m_pdata->getPositions(), access_location::device, access_mode::read);
-    ArrayHandle<Scalar4> d_params(m_params, access_location::device, access_mode::read);
-
-    m_tuner->begin();
-    gpu::compute_implicit_evap_force(d_force.data,
-                                       d_virial.data,
-                                       d_pos.data,
-                                       d_params.data,
-                                       interf_origin,
-                                       m_pdata->getN(),
-                                       m_pdata->getNTypes(),
-                                       m_tuner->getParam());
-    if (m_exec_conf->isCUDAErrorCheckingEnabled()) CHECK_CUDA_ERROR();
-    m_tuner->end();
-    }
-
 namespace detail
 {
 /*!
@@ -71,8 +32,8 @@ namespace detail
 void export_ImplicitEvaporatorGPU(pybind11::module& m)
     {
     namespace py = pybind11;
-    py::class_< ImplicitEvaporatorGPU, std::shared_ptr<ImplicitEvaporatorGPU> >(m, "ImplicitEvaporatorGPU", py::base<ImplicitEvaporator>())
-        .def(py::init< std::shared_ptr<SystemDefinition>, std::shared_ptr<Variant> >())
+    py::class_<ImplicitEvaporatorGPU,std::shared_ptr<ImplicitEvaporatorGPU>>(m, "ImplicitEvaporatorGPU", py::base<ImplicitEvaporator>())
+        .def(py::init<std::shared_ptr<SystemDefinition>,std::shared_ptr<Variant>>())
     ;
     }
 } // end namespace detail

--- a/azplugins/ImplicitEvaporatorGPU.h
+++ b/azplugins/ImplicitEvaporatorGPU.h
@@ -24,8 +24,9 @@ namespace azplugins
 
 //! Implicit solvent evaporator on the GPU
 /*!
- * \warning The virial is not computed for this external potential, and a warning
- *          will be raised the first time it is requested.
+ * This class does not implement any force evaluation on its own, as the geometry should be
+ * implemented by deriving classes. It exists as a thin layer between ImplicitEvaporator
+ * to remove some boilerplate of setting up the autotuners.
  */
 class PYBIND11_EXPORT ImplicitEvaporatorGPU : public ImplicitEvaporator
     {
@@ -33,9 +34,6 @@ class PYBIND11_EXPORT ImplicitEvaporatorGPU : public ImplicitEvaporator
         //! Constructor
         ImplicitEvaporatorGPU(std::shared_ptr<SystemDefinition> sysdef,
                               std::shared_ptr<Variant> interf);
-
-        //! Destructor
-        virtual ~ImplicitEvaporatorGPU() {};
 
         //! Set autotuner parameters
         /*!
@@ -50,10 +48,6 @@ class PYBIND11_EXPORT ImplicitEvaporatorGPU : public ImplicitEvaporator
             }
 
     protected:
-        //! Implements the force calculation
-        virtual void computeForces(unsigned int timestep);
-
-    private:
         std::unique_ptr<Autotuner> m_tuner;   //!< Autotuner for block size
     };
 

--- a/azplugins/ImplicitPlaneEvaporator.cc
+++ b/azplugins/ImplicitPlaneEvaporator.cc
@@ -1,0 +1,98 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file ImplicitPlaneEvaporator.cc
+ * \brief Definition of ImplicitPlaneEvaporator
+ */
+
+#include "ImplicitPlaneEvaporator.h"
+
+namespace azplugins
+{
+/*!
+ * \param sysdef System definition
+ * \param interf Position of the interface
+ */
+ImplicitPlaneEvaporator::ImplicitPlaneEvaporator(std::shared_ptr<SystemDefinition> sysdef,
+                                                 std::shared_ptr<Variant> interf)
+        : ImplicitEvaporator(sysdef, interf)
+    {
+    m_exec_conf->msg->notice(5) << "Constructing ImplicitPlaneEvaporator" << std::endl;
+    }
+
+ImplicitPlaneEvaporator::~ImplicitPlaneEvaporator()
+    {
+    m_exec_conf->msg->notice(5) << "Destroying ImplicitPlaneEvaporator" << std::endl;
+    }
+
+/*!
+ * \param timestep Current timestep
+ */
+void ImplicitPlaneEvaporator::computeForces(unsigned int timestep)
+    {
+    ImplicitEvaporator::computeForces(timestep);
+
+    const BoxDim& box = m_pdata->getGlobalBox();
+    const Scalar interf_origin = m_interf->getValue(timestep);
+    if (interf_origin > box.getHi().z || interf_origin < box.getLo().z)
+        {
+        m_exec_conf->msg->error() << "ImplicitPlaneEvaporator interface must be inside the simulation box" << std::endl;
+        throw std::runtime_error("ImplicitPlaneEvaporator interface must be inside the simulation box");
+        }
+
+    ArrayHandle<Scalar4> h_force(m_force, access_location::host, access_mode::overwrite);
+    ArrayHandle<Scalar> h_virial(m_virial, access_location::host, access_mode::overwrite);
+    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
+    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+
+    ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host, access_mode::read);
+    ArrayHandle<Scalar4> h_params(m_params, access_location::host, access_mode::read);
+    for (unsigned int idx = 0; idx < m_pdata->getN(); ++idx)
+        {
+        const Scalar4 postype_i = h_pos.data[idx];
+        const Scalar z_i = postype_i.z;
+        const unsigned int type_i = __scalar_as_int(postype_i.w);
+
+        const Scalar4 params = h_params.data[type_i];
+        const Scalar k = params.x;
+        const Scalar offset = params.y;
+        const Scalar g = params.z;
+        const Scalar cutoff = params.w;
+
+        const Scalar dz = z_i - (interf_origin + offset);
+        if (cutoff < Scalar(0.0) || dz < Scalar(0.0)) continue;
+
+        Scalar fz(0.0), e(0.0);
+        if (dz < cutoff) // harmonic
+            {
+            fz = -k * dz;
+            e = Scalar(-0.5) * fz * dz; // (k/2) dz^2
+            }
+        else // linear
+            {
+            fz = -g;
+            e = Scalar(0.5) * k * cutoff * cutoff + g * (dz - cutoff);
+            }
+
+        h_force.data[idx] = make_scalar4(0.0, 0.0, fz, e);
+        }
+    }
+
+namespace detail
+{
+/*!
+ * \param m Python module to export to
+ */
+void export_ImplicitPlaneEvaporator(pybind11::module& m)
+    {
+    namespace py = pybind11;
+    py::class_<ImplicitPlaneEvaporator,std::shared_ptr<ImplicitPlaneEvaporator>>(m, "ImplicitPlaneEvaporator", py::base<ImplicitEvaporator>())
+        .def(py::init<std::shared_ptr<SystemDefinition>,std::shared_ptr<Variant>>());
+    ;
+    }
+} // end namespace detail
+
+} // end namespace azplugins

--- a/azplugins/ImplicitPlaneEvaporator.h
+++ b/azplugins/ImplicitPlaneEvaporator.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file ImplicitPlaneEvaporator.h
+ * \brief Declaration of ImplicitPlaneEvaporator
+ */
+
+#ifndef AZPLUGINS_IMPLICIT_PLANE_EVAPORATOR_H_
+#define AZPLUGINS_IMPLICIT_PLANE_EVAPORATOR_H_
+
+#ifdef NVCC
+#error This header cannot be compiled by nvcc
+#endif
+
+#include "ImplicitEvaporator.h"
+
+#include "hoomd/extern/pybind/include/pybind11/pybind11.h"
+
+namespace azplugins
+{
+
+//! Implicit solvent evaporator in a planar (thin film) geometry
+/*!
+ * The interface normal is defined along +z going from the liquid into the vapor phase,
+ * and the origin is z = 0. This effectively models a drying thin film.
+ */
+class PYBIND11_EXPORT ImplicitPlaneEvaporator : public ImplicitEvaporator
+    {
+    public:
+        //! Constructor
+        ImplicitPlaneEvaporator(std::shared_ptr<SystemDefinition> sysdef,
+                                std::shared_ptr<Variant> interf);
+
+        virtual ~ImplicitPlaneEvaporator();
+
+    protected:
+        //! Implements the force calculation
+        virtual void computeForces(unsigned int timestep);
+    };
+
+namespace detail
+{
+//! Exports the ImplicitPlaneEvaporator to python
+void export_ImplicitPlaneEvaporator(pybind11::module& m);
+} // end namespace detail
+
+} // end namespace azplugins
+
+#endif // AZPLUGINS_IMPLICIT_PLANE_EVAPORATOR_H_

--- a/azplugins/ImplicitPlaneEvaporatorGPU.cc
+++ b/azplugins/ImplicitPlaneEvaporatorGPU.cc
@@ -1,0 +1,80 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file ImplicitPlaneEvaporatorGPU.cc
+ * \brief Definition of ImplicitPlaneEvaporatorGPU
+ */
+
+#include "ImplicitPlaneEvaporatorGPU.h"
+#include "ImplicitPlaneEvaporatorGPU.cuh"
+
+namespace azplugins
+{
+
+/*!
+ * \param sysdef System definition
+ * \param interf Position of the interface
+ */
+ImplicitPlaneEvaporatorGPU::ImplicitPlaneEvaporatorGPU(std::shared_ptr<SystemDefinition> sysdef,
+                                                       std::shared_ptr<Variant> interf)
+        : ImplicitEvaporatorGPU(sysdef, interf)
+    {
+    m_exec_conf->msg->notice(5) << "Constructing ImplicitPlaneEvaporatorGPU" << std::endl;
+    }
+
+ImplicitPlaneEvaporatorGPU::~ImplicitPlaneEvaporatorGPU()
+    {
+    m_exec_conf->msg->notice(5) << "Destroying ImplicitPlaneEvaporatorGPU" << std::endl;
+    }
+
+/*!
+ * \param timestep Current timestep
+ */
+void ImplicitPlaneEvaporatorGPU::computeForces(unsigned int timestep)
+    {
+    ImplicitEvaporatorGPU::computeForces(timestep);
+
+    const BoxDim& box = m_pdata->getGlobalBox();
+    const Scalar interf_origin = m_interf->getValue(timestep);
+    if (interf_origin > box.getHi().z || interf_origin < box.getLo().z)
+        {
+        m_exec_conf->msg->error() << "ImplicitEvaporator interface must be inside the simulation box" << std::endl;
+        throw std::runtime_error("ImplicitEvaporator interface must be inside the simulation box");
+        }
+
+    ArrayHandle<Scalar4> d_force(m_force, access_location::device, access_mode::overwrite);
+    ArrayHandle<Scalar> d_virial(m_virial, access_location::device, access_mode::overwrite);
+    ArrayHandle<Scalar4> d_pos(m_pdata->getPositions(), access_location::device, access_mode::read);
+    ArrayHandle<Scalar4> d_params(m_params, access_location::device, access_mode::read);
+
+    m_tuner->begin();
+    gpu::compute_implicit_evap_force(d_force.data,
+                                       d_virial.data,
+                                       d_pos.data,
+                                       d_params.data,
+                                       interf_origin,
+                                       m_pdata->getN(),
+                                       m_pdata->getNTypes(),
+                                       m_tuner->getParam());
+    if (m_exec_conf->isCUDAErrorCheckingEnabled()) CHECK_CUDA_ERROR();
+    m_tuner->end();
+    }
+
+namespace detail
+{
+/*!
+ * \param m Python module to export to
+ */
+void export_ImplicitPlaneEvaporatorGPU(pybind11::module& m)
+    {
+    namespace py = pybind11;
+    py::class_<ImplicitPlaneEvaporatorGPU,std::shared_ptr<ImplicitPlaneEvaporatorGPU> >(m, "ImplicitPlaneEvaporatorGPU", py::base<ImplicitEvaporatorGPU>())
+        .def(py::init<std::shared_ptr<SystemDefinition>,std::shared_ptr<Variant>>())
+    ;
+    }
+} // end namespace detail
+
+} // end namespace azplugins

--- a/azplugins/ImplicitPlaneEvaporatorGPU.cu
+++ b/azplugins/ImplicitPlaneEvaporatorGPU.cu
@@ -4,11 +4,11 @@
 // Maintainer: mphoward
 
 /*!
- * \file ImplicitEvaporatorGPU.cu
- * \brief Definition of kernel drivers and kernels for ImplicitEvaporatorGPU
+ * \file ImplicitPlaneEvaporatorGPU.cu
+ * \brief Definition of kernel drivers and kernels for ImplicitPlaneEvaporatorGPU
  */
 
-#include "ImplicitEvaporatorGPU.cuh"
+#include "ImplicitPlaneEvaporatorGPU.cuh"
 
 namespace azplugins
 {

--- a/azplugins/ImplicitPlaneEvaporatorGPU.cuh
+++ b/azplugins/ImplicitPlaneEvaporatorGPU.cuh
@@ -4,12 +4,12 @@
 // Maintainer: mphoward
 
 /*!
- * \file ImplicitEvaporatorGPU.cuh
- * \brief Declaration of kernel drivers for ImplicitEvaporatorGPU
+ * \file ImplicitPlaneEvaporatorGPU.cuh
+ * \brief Declaration of kernel drivers for ImplicitPlaneEvaporatorGPU
  */
 
-#ifndef AZPLUGINS_IMPLICIT_EVAPORATOR_GPU_CUH_
-#define AZPLUGINS_IMPLICIT_EVAPORATOR_GPU_CUH_
+#ifndef AZPLUGINS_IMPLICIT_PLANE_EVAPORATOR_GPU_CUH_
+#define AZPLUGINS_IMPLICIT_PLANE_EVAPORATOR_GPU_CUH_
 
 #include <cuda_runtime.h>
 #include "hoomd/HOOMDMath.h"
@@ -19,7 +19,7 @@ namespace azplugins
 namespace gpu
 {
 
-//! Kernel driver to evaluate ImplicitEvaporatorGPU force
+//! Kernel driver to evaluate ImplicitPlaneEvaporatorGPU force
 cudaError_t compute_implicit_evap_force(Scalar4 *d_force,
                                         Scalar *d_virial,
                                         const Scalar4 *d_pos,
@@ -32,4 +32,4 @@ cudaError_t compute_implicit_evap_force(Scalar4 *d_force,
 } // end namespace gpu
 } // end namespace azplugins
 
-#endif // AZPLUGINS_IMPLICIT_EVAPORATOR_GPU_CUH_
+#endif // AZPLUGINS_IMPLICIT_PLANE_EVAPORATOR_GPU_CUH_

--- a/azplugins/ImplicitPlaneEvaporatorGPU.h
+++ b/azplugins/ImplicitPlaneEvaporatorGPU.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file ImplicitPlaneEvaporatorGPU.h
+ * \brief Declaration of ImplicitPlaneEvaporatorGPU
+ */
+
+#ifndef AZPLUGINS_IMPLICIT_PLANE_EVAPORATOR_GPU_H_
+#define AZPLUGINS_IMPLICIT_PLANE_EVAPORATOR_GPU_H_
+
+#ifdef NVCC
+#error This header cannot be compiled by nvcc
+#endif
+
+#include "ImplicitEvaporatorGPU.h"
+
+namespace azplugins
+{
+
+//! Implicit solvent evaporator in a planar (thin film) geometry (on the GPU)
+class PYBIND11_EXPORT ImplicitPlaneEvaporatorGPU : public ImplicitEvaporatorGPU
+    {
+    public:
+        //! Constructor
+        ImplicitPlaneEvaporatorGPU(std::shared_ptr<SystemDefinition> sysdef,
+                                   std::shared_ptr<Variant> interf);
+
+        //! Destructor
+        virtual ~ImplicitPlaneEvaporatorGPU();
+
+    protected:
+        //! Implements the force calculation
+        virtual void computeForces(unsigned int timestep);
+    };
+
+namespace detail
+{
+//! Exports the ImplicitPlaneEvaporatorGPU to python
+void export_ImplicitPlaneEvaporatorGPU(pybind11::module& m);
+} // end namespace detail
+
+} // end namespace azplugins
+
+#endif // AZPLUGINS_IMPLICIT_PLANE_EVAPORATOR_GPU_H_

--- a/azplugins/evaporate.py
+++ b/azplugins/evaporate.py
@@ -23,12 +23,12 @@ class implicit(hoomd.md.force._force):
         :nowrap:
 
         \begin{eqnarray*}
-        V(z) = & 0 & z < H \\
-               & \frac{\kappa}{2} (z-H)^2 & H \le z < H_{\rm c} \\
-               & \frac{\kappa}{2} (H_{\rm c} - H)^2 - F_g (z - H_{\rm c}) & z \ge H_{\rm c}
+        V(d) = & 0 & d < H \\
+               & \frac{\kappa}{2} (d-H)^2 & H \le d < H_{\rm c} \\
+               & \frac{\kappa}{2} (H_{\rm c} - H)^2 - F_g (d - H_{\rm c}) & d \ge H_{\rm c}
         \end{eqnarray*}
 
-    Here, the interface is located at *z* height *H*, and may change with time.
+    Here, the interface is located at height *H*, and may change with time.
     The effective interface position *H* may be modified per-particle-type using a *offset*
     (*offset* is added to *H* to determine the effective *H*).
     :math:`\kappa` is a spring constant setting the strength of the interface
@@ -43,13 +43,12 @@ class implicit(hoomd.md.force._force):
     (the force is continuous) and also that :math:`F_g` scales with the cube of the
     particle radius.
 
-    The drying *geometry* determines the physical meaning of *z* and *H*. Currently,
+    The drying *geometry* determines the physical meaning of *d* and *H*. Currently,
     it can be:
 
-    - *film*: A drying thin film (planar geometry), where *z* is the particle's
-              z-coordinate of the particle and *H* is then the film height.
-              This is the default value.
-    - *droplet*: A drying droplet (spherical geometry), where *z* is the particle's
+    - *film*: A drying thin film (planar geometry), where *d* is the particle's
+              z-coordinate and *H* is then the film height. This is the default value.
+    - *droplet*: A drying droplet (spherical geometry), where *d* is the particle's
                  radial distance from the origin and *H* is then the droplet radius.
 
     The following coefficinets must be set per unique particle type:

--- a/azplugins/evaporate.py
+++ b/azplugins/evaporate.py
@@ -13,6 +13,7 @@ class implicit(hoomd.md.force._force):
     Args:
         interface (:py:mod:`hoomd.variant` or :py:obj:`float`): *z* position of interface
         name (str): Name of the model instance
+        geometry (str): Drying geometry ("film" or "droplet").
 
     An evaporating solvent front is modeled implicitly by a purely repulsive
     harmonic interface that pushes down on nonvolatile solutes. The potential
@@ -41,6 +42,15 @@ class implicit(hoomd.md.force._force):
     :math:`F_g = -\kappa \Delta` so that the potential is continued linearly
     (the force is continuous) and also that :math:`F_g` scales with the cube of the
     particle radius.
+
+    The drying *geometry* determines the physical meaning of *z* and *H*. Currently,
+    it can be:
+
+    - *film*: A drying thin film (planar geometry), where *z* is the particle's
+              z-coordinate of the particle and *H* is then the film height.
+              This is the default value.
+    - *droplet*: A drying droplet (spherical geometry), where *z* is the particle's
+                 radial distance from the origin and *H* is then the droplet radius.
 
     The following coefficinets must be set per unique particle type:
 
@@ -72,7 +82,7 @@ class implicit(hoomd.md.force._force):
         pressure (tensor) is not being logged or the pressure is not of interest.
 
     """
-    def __init__(self, interface, name=""):
+    def __init__(self, interface, name="", geometry='film'):
         hoomd.util.print_status_line()
 
         # initialize the base class
@@ -80,18 +90,31 @@ class implicit(hoomd.md.force._force):
 
         # setup the (moving) interface variant
         self.interface = hoomd.variant._setup_variant_input(interface)
+        self.geometry = geometry
 
         # setup the coefficient vector
         self.force_coeff = hoomd.md.external.coeff()
         self.force_coeff.set_default_coeff('offset', 0.0)
         self.required_coeffs = ['k','offset','g','cutoff']
-        self.metadata_fields = ['force_coeff','interface']
+        self.metadata_fields = ['force_coeff','interface','geometry']
 
         # create the c++ mirror class
         if not hoomd.context.exec_conf.isCUDAEnabled():
-            cpp_class = _azplugins.ImplicitEvaporator
+            if geometry == 'film':
+                cpp_class = _azplugins.ImplicitPlaneEvaporator
+            elif geometry == 'droplet':
+                cpp_class = _azplugins.ImplicitDropletEvaporator
+            else:
+                hoomd.context.msg.error('Unrecognized implicit drying geometry {}\n'.format(geometry))
+                raise ValueError('Unrecognized implicit drying geometry')
         else:
-            cpp_class = _azplugins.ImplicitEvaporatorGPU
+            if geometry == 'film':
+                cpp_class = _azplugins.ImplicitPlaneEvaporatorGPU
+            elif geometry == 'droplet':
+                cpp_class = _azplugins.ImplicitDropletEvaporatorGPU
+            else:
+                hoomd.context.msg.error('Unrecognized implicit drying geometry {}\n'.format(geometry))
+                raise ValueError('Unrecognized implicit drying geometry')
         self.cpp_force = cpp_class(hoomd.context.current.system_definition, self.interface.cpp_variant)
 
         hoomd.context.current.system.addCompute(self.cpp_force, self.force_name)
@@ -127,6 +150,7 @@ class implicit(hoomd.md.force._force):
 
         data['force_coeff'] = self.force_coeff
         data['interface'] = self.interface
+        data['geometry'] = self.geometry
 
         return data
 

--- a/azplugins/module.cc
+++ b/azplugins/module.cc
@@ -39,10 +39,14 @@ namespace py = pybind11;
 
 /* Force computes */
 #include "ImplicitEvaporator.h"
+#include "ImplicitDropletEvaporator.h"
+#include "ImplicitPlaneEvaporator.h"
 #include "OrientationRestraintCompute.h"
 #include "PositionRestraintCompute.h"
 #ifdef ENABLE_CUDA
 #include "ImplicitEvaporatorGPU.h"
+#include "ImplicitDropletEvaporatorGPU.h"
+#include "ImplicitPlaneEvaporatorGPU.h"
 #include "OrientationRestraintComputeGPU.h"
 #include "PositionRestraintComputeGPU.h"
 #endif // ENABLE_CUDA
@@ -195,10 +199,14 @@ PYBIND11_MODULE(_azplugins, m)
 
     /* Force computes */
     azplugins::detail::export_ImplicitEvaporator(m);
+    azplugins::detail::export_ImplicitDropletEvaporator(m);
+    azplugins::detail::export_ImplicitPlaneEvaporator(m);
     azplugins::detail::export_OrientationRestraintCompute(m);
     azplugins::detail::export_PositionRestraintCompute(m);
     #ifdef ENABLE_CUDA
     azplugins::detail::export_ImplicitEvaporatorGPU(m);
+    azplugins::detail::export_ImplicitDropletEvaporatorGPU(m);
+    azplugins::detail::export_ImplicitPlaneEvaporatorGPU(m);
     azplugins::detail::export_OrientationRestraintComputeGPU(m);
     azplugins::detail::export_PositionRestraintComputeGPU(m);
     #endif // ENABLE_CUDA


### PR DESCRIPTION
This PR implements the moving harmonic potential that mimics evaporation in a spherical geometry, as in [Liu et al.](https://doi.org/10.1021/acsnano.9b00459) Since the original command for the thin film evaporator was `evaporate.implicit` and the class structures are highly similar, I decided to add a `geometry` option to this command that can be either `'film'` (default, original behavior) or `'droplet'` (new geometry). This supports extension to other geometries like cylinders. On the C++ side, there is now a base `ImplicitEvaporator`, from which the geometries and GPU versions derive. Technically, this is probably better achieved using templates to compute the distance and normal to the interface rather than subclassing, but this was faster to implement. The code can be refactored later if we want without changing the public API.