### PR TITLE
Refactor pair evaluators for HOOMD 2.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   mphoward:
     docker:
-      - image: mphoward/ci:hoomd2.6.0-ubuntu18.04
+      - image: mphoward/ci:hoomd<< parameters.hoomd-version >>-ubuntu18.04
     working_directory: /home/ci/project
 
 commands:
@@ -72,6 +72,9 @@ commands:
 jobs:
   ext_build:
     parameters:
+      hoomd-version:
+        type: string
+        default: "2.6.0"
       python-version:
         type: string
         default: "3"
@@ -88,6 +91,9 @@ jobs:
 
   ext_build_and_test:
     parameters:
+      hoomd-version:
+        type: string
+        default: "2.6.0"
       python-version:
         type: string
         default: "3"
@@ -105,6 +111,9 @@ jobs:
 
   int_build_and_test:
     parameters:
+      hoomd-version:
+        type: string
+        default: "2.6.0"
       python-version:
         type: string
         default: "3"
@@ -168,3 +177,47 @@ workflows:
       - int_build_and_test:
           name: py2-internal
           python-version: "2"
+
+      - ext_build_and_test:
+          name: 2.8.0-nocuda-nompi-double
+          hoomd-version: "2.8.0"
+          hoomd-config: "nocuda/nompi/double"
+
+      - ext_build_and_test:
+          name: 2.8.0-nocuda-nompi-single
+          hoomd-version: "2.8.0"
+          hoomd-config: "nocuda/nompi/single"
+
+      - ext_build_and_test:
+          name: 2.8.0-nocuda-mpi-double
+          hoomd-version: "2.8.0"
+          hoomd-config: "nocuda/mpi/double"
+
+      - ext_build_and_test:
+          name: 2.8.0-nocuda-mpi-single
+          hoomd-version: "2.8.0"
+          hoomd-config: "nocuda/mpi/single"
+
+      - ext_build:
+          name: 2.8.0-cuda-nompi-double
+          hoomd-version: "2.8.0"
+          hoomd-config: "cuda/nompi/double"
+
+      - ext_build:
+          name: 2.8.0-cuda-nompi-single
+          hoomd-version: "2.8.0"
+          hoomd-config: "cuda/nompi/single"
+
+      - ext_build:
+          name: 2.8.0-cuda-mpi-double
+          hoomd-version: "2.8.0"
+          hoomd-config: "cuda/mpi/double"
+
+      - ext_build:
+          name: 2.8.0-cuda-mpi-single
+          hoomd-version: "2.8.0"
+          hoomd-config: "cuda/mpi/single"
+
+      - int_build_and_test:
+          name: 2.8.0-internal
+          hoomd-version: "2.8.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,9 @@ version: 2.1
 
 executors:
   mphoward:
+    parameters:
+      hoomd-version:
+        type: string
     docker:
       - image: mphoward/ci:hoomd<< parameters.hoomd-version >>-ubuntu18.04
     working_directory: /home/ci/project
@@ -82,6 +85,7 @@ jobs:
         type: string
     executor:
       name: mphoward
+      hoomd-version: << parameters.hoomd-version >>
     environment:
       PYTHONPATH: "/home/ci/project/build:/opt/hoomd/python<< parameters.python-version>>/<< parameters.hoomd-config >>"
       PYTHON: "/usr/bin/python<< parameters.python-version >>"
@@ -101,6 +105,7 @@ jobs:
         type: string
     executor:
       name: mphoward
+      hoomd-version: << parameters.hoomd-version >>
     environment:
       PYTHONPATH: "/home/ci/project/build:/opt/hoomd/python<< parameters.python-version>>/<< parameters.hoomd-config >>"
       PYTHON: "/usr/bin/python<< parameters.python-version >>"
@@ -122,6 +127,7 @@ jobs:
         default: on
     executor:
       name: mphoward
+      hoomd-version: << parameters.hoomd-version >>
     environment:
       PYTHONPATH: "/home/ci/project/build"
       PYTHON: "/usr/bin/python<< parameters.python-version >>"

--- a/.circleci/images/hoomd2.8.0/Dockerfile
+++ b/.circleci/images/hoomd2.8.0/Dockerfile
@@ -1,0 +1,109 @@
+FROM nvidia/cuda:10.1-devel-ubuntu18.04
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    cmake \
+    curl \
+    git \
+    openssh-client \
+    python3 \
+    python3-dev \
+    python3-numpy \
+    python3-sphinx \
+    python3-sphinx-rtd-theme \
+    zlib1g-dev \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# prevent python from loading paths outside the container
+ENV PYTHONPATH=/ignore/pythonpath
+RUN sed -i -e 's/ENABLE_USER_SITE = None/ENABLE_USER_SITE = False/g' `python3 -c 'import site; print(site.__file__)'`
+
+# openmpi 3.0 library
+RUN curl -sSLO https://www.open-mpi.org/software/ompi/v3.0/downloads/openmpi-3.0.0.tar.bz2 \
+   && echo "f699bff21db0125d8cccfe79518b77641cd83628725a1e1ed3e45633496a82d7  openmpi-3.0.0.tar.bz2" | sha256sum -c - \
+   && tar -xjf openmpi-3.0.0.tar.bz2 -C /root \
+   && cd /root/openmpi-3.0.0 \
+   && ./configure --prefix=/usr \
+   && make all install \
+   && rm -rf /root/openmpi-3.0.0 \
+   && rm /openmpi-3.0.0.tar.bz2
+
+# configure unprivileged ci user that will also receive source code
+RUN useradd --create-home --shell /bin/bash ci
+
+# get HOOMD source code and unpack for the ci user (for internal build tests)
+RUN curl -sSLO https://glotzerlab.engin.umich.edu/Downloads/hoomd/hoomd-v2.8.0.tar.gz \
+    && echo "f3cd733bb9a8932a30d65927897eaff894bf5ddb7a95c507ee47e124a7a4f541  hoomd-v2.8.0.tar.gz" | sha256sum -c - \
+    && tar -xzf hoomd-v2.8.0.tar.gz -C /home/ci \
+    && mv /home/ci/hoomd-v2.8.0 /home/ci/hoomd \
+    && rm -f /home/ci/hoomd/hoomd/example_plugin \
+    && chown -R ci:ci /home/ci/hoomd \
+    && rm /hoomd-v2.8.0.tar.gz
+
+# hoomd + MD + MPCD in various build configurations
+# python3 + nocuda + nompi + double
+RUN mkdir -p /root/build \
+    && cd /root/build \
+    && export CFLAGS="" CXXFLAGS="" \
+    && cmake /home/ci/hoomd -DPYTHON_EXECUTABLE="`which python3`" -DENABLE_CUDA=off -DENABLE_MPI=off -DSINGLE_PRECISION=off -DENABLE_TBB=off -DBUILD_CGCMM=off -DBUILD_DEM=off -DBUILD_DEPRECATED=off -DBUILD_HPMC=off -DBUILD_JIT=off -DBUILD_METAL=OFF -DBUILD_TESTING=off -DCMAKE_INSTALL_PREFIX=/opt/hoomd/python3/nocuda/nompi/double \
+    && make install \
+    && rm -rf /root/build
+
+# python3 + nocuda + nompi + single
+RUN mkdir -p /root/build \
+    && cd /root/build \
+    && export CFLAGS="" CXXFLAGS="" \
+    && cmake /home/ci/hoomd -DPYTHON_EXECUTABLE="`which python3`" -DENABLE_CUDA=off -DENABLE_MPI=off -DSINGLE_PRECISION=on -DENABLE_TBB=off -DBUILD_CGCMM=off -DBUILD_DEM=off -DBUILD_DEPRECATED=off -DBUILD_HPMC=off -DBUILD_JIT=off -DBUILD_METAL=OFF -DBUILD_TESTING=off -DCMAKE_INSTALL_PREFIX=/opt/hoomd/python3/nocuda/nompi/single \
+    && make install \
+    && rm -rf /root/build
+
+# python3 + cuda + nompi + double
+RUN mkdir -p /root/build \
+    && cd /root/build \
+    && export CFLAGS="" CXXFLAGS="" \
+    && cmake /home/ci/hoomd -DPYTHON_EXECUTABLE="`which python3`" -DENABLE_CUDA=on -DENABLE_MPI=off -DSINGLE_PRECISION=off -DENABLE_TBB=off -DBUILD_CGCMM=off -DBUILD_DEM=off -DBUILD_DEPRECATED=off -DBUILD_HPMC=off -DBUILD_JIT=off -DBUILD_METAL=OFF -DBUILD_TESTING=off -DCMAKE_INSTALL_PREFIX=/opt/hoomd/python3/cuda/nompi/double \
+    && make install \
+    && rm -rf /root/build
+
+# python3 + cuda + nompi + single
+RUN mkdir -p /root/build \
+    && cd /root/build \
+    && export CFLAGS="" CXXFLAGS="" \
+    && cmake /home/ci/hoomd -DPYTHON_EXECUTABLE="`which python3`" -DENABLE_CUDA=on -DENABLE_MPI=off -DSINGLE_PRECISION=on -DENABLE_TBB=off -DBUILD_CGCMM=off -DBUILD_DEM=off -DBUILD_DEPRECATED=off -DBUILD_HPMC=off -DBUILD_JIT=off -DBUILD_METAL=OFF -DBUILD_TESTING=off -DCMAKE_INSTALL_PREFIX=/opt/hoomd/python3/cuda/nompi/single \
+    && make install \
+    && rm -rf /root/build
+
+# python3 + nocuda + mpi + double
+RUN mkdir -p /root/build \
+    && cd /root/build \
+    && export CFLAGS="" CXXFLAGS="" \
+    && cmake /home/ci/hoomd -DPYTHON_EXECUTABLE="`which python3`" -DENABLE_CUDA=off -DENABLE_MPI=on -DSINGLE_PRECISION=off -DENABLE_TBB=off -DBUILD_CGCMM=off -DBUILD_DEM=off -DBUILD_DEPRECATED=off -DBUILD_HPMC=off -DBUILD_JIT=off -DBUILD_METAL=OFF -DBUILD_TESTING=off -DENABLE_MPI_CUDA=off -DCMAKE_INSTALL_PREFIX=/opt/hoomd/python3/nocuda/mpi/double \
+    && make install \
+    && rm -rf /root/build
+
+# python3 + nocuda + mpi + single
+RUN mkdir -p /root/build \
+    && cd /root/build \
+    && export CFLAGS="" CXXFLAGS="" \
+    && cmake /home/ci/hoomd -DPYTHON_EXECUTABLE="`which python3`" -DENABLE_CUDA=off -DENABLE_MPI=on -DSINGLE_PRECISION=on -DENABLE_TBB=off -DBUILD_CGCMM=off -DBUILD_DEM=off -DBUILD_DEPRECATED=off -DBUILD_HPMC=off -DBUILD_JIT=off -DBUILD_METAL=OFF -DBUILD_TESTING=off -DENABLE_MPI_CUDA=off -DCMAKE_INSTALL_PREFIX=/opt/hoomd/python3/nocuda/mpi/single \
+    && make install \
+    && rm -rf /root/build
+
+# python3 + cuda + mpi + double
+RUN mkdir -p /root/build \
+    && cd /root/build \
+    && export CFLAGS="" CXXFLAGS="" \
+    && cmake /home/ci/hoomd -DPYTHON_EXECUTABLE="`which python3`" -DENABLE_CUDA=on -DENABLE_MPI=on -DSINGLE_PRECISION=off -DENABLE_TBB=off -DBUILD_CGCMM=off -DBUILD_DEM=off -DBUILD_DEPRECATED=off -DBUILD_HPMC=off -DBUILD_JIT=off -DBUILD_METAL=OFF -DBUILD_TESTING=off -DENABLE_MPI_CUDA=off -DCMAKE_INSTALL_PREFIX=/opt/hoomd/python3/cuda/mpi/double \
+    && make install \
+    && rm -rf /root/build
+
+# python3 + cuda + mpi + single
+RUN mkdir -p /root/build \
+    && cd /root/build \
+    && export CFLAGS="" CXXFLAGS="" \
+    && cmake /home/ci/hoomd -DPYTHON_EXECUTABLE="`which python3`" -DENABLE_CUDA=on -DENABLE_MPI=on -DSINGLE_PRECISION=on -DENABLE_TBB=off -DBUILD_CGCMM=off -DBUILD_DEM=off -DBUILD_DEPRECATED=off -DBUILD_HPMC=off -DBUILD_JIT=off -DBUILD_METAL=OFF -DBUILD_TESTING=off -DENABLE_MPI_CUDA=off -DCMAKE_INSTALL_PREFIX=/opt/hoomd/python3/cuda/mpi/single \
+    && make install \
+    && rm -rf /root/build
+
+# switch to ci user
+USER ci:ci

--- a/azplugins/AnisoPairEvaluator.h
+++ b/azplugins/AnisoPairEvaluator.h
@@ -1,0 +1,188 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file AnisoPairEvaluator.h
+ * \brief Base class for anisotropic pair evaluators.
+ */
+
+#ifndef AZPLUGINS_ANISO_PAIR_EVALUATOR_H_
+#define AZPLUGINS_ANISO_PAIR_EVALUATOR_H_
+
+#include "hoomd/HOOMDMath.h"
+
+#ifdef NVCC
+#define DEVICE __device__
+#define HOSTDEVICE __host__ __device__
+#else
+#define DEVICE
+#define HOSTDEVICE
+#include <string>
+#endif
+
+namespace azplugins
+{
+namespace detail
+{
+
+//! Base class for anisotropic pair parameters
+/*!
+ * These types of parameters do nothing by default.
+ */
+struct AnisoPairParams
+    {
+    HOSTDEVICE AnisoPairParams() {}
+
+    //! Load dynamic data members into shared memory and increase pointer
+    /*!
+     * \param ptr Pointer to load data to (will be incremented)
+     * \param available_bytes Size of remaining shared memory allocation
+     *
+     * This does nothing for this struct.
+     */
+    HOSTDEVICE void load_shared(char *& ptr, unsigned int &available_bytes) const {}
+    };
+
+//! Base class for anisotropic shape parameters
+/*!
+ * These types of parameters do nothing by default.
+ */
+struct AnisoShapeParams
+    {
+    HOSTDEVICE AnisoShapeParams() {}
+
+    //! Load dynamic data members into shared memory and increase pointer
+    /*!
+     * \param ptr Pointer to load data to (will be incremented)
+     * \param available_bytes Size of remaining shared memory allocation
+     *
+     * This does nothing for this struct.
+     */
+    HOSTDEVICE void load_shared(char *& ptr, unsigned int &available_bytes) const {}
+
+    #ifdef ENABLE_CUDA
+    //! Attach managed memory to CUDA stream
+    void attach_to_stream(cudaStream_t stream) const {}
+    #endif
+    };
+
+//! Base class for anisotropic pair potential evaluator
+/*!
+ * This class covers the default case of a simple potential that doesn't require
+ * additional data. Its constructor stores the common variables. The class can
+ * be overridden for more complex potentials.
+ *
+ * Deriving classes \b must define a \a param_type and a \a shape_param_type
+ * (which can simply be a redeclaration of the one here). They must also
+ * give the potential a name and implement the evaluate() method.
+ */
+class AnisoPairEvaluator
+    {
+    public:
+        typedef AnisoShapeParams shape_param_type;
+
+        DEVICE AnisoPairEvaluator(const Scalar3& _dr,
+                                  const Scalar4& _quat_i,
+                                  const Scalar4& _quat_j,
+                                  const Scalar _rcutsq)
+        : dr(_dr), rcutsq(_rcutsq), quat_i(_quat_i), quat_j(_quat_j)
+        {}
+
+        //! Base potential does not need diameter
+        DEVICE static bool needsDiameter()
+            {
+            return false;
+            }
+
+        //! Accept the optional diameter values
+        /*!
+         * \param di Diameter of particle i
+         * \param dj Diameter of particle j
+         */
+        DEVICE void setDiameter(Scalar di, Scalar dj) {}
+
+        //! Base potential does not need charge
+        DEVICE static bool needsCharge()
+            {
+            return false;
+            }
+
+        //! Accept the optional charge values
+        /*!
+         * \param qi Charge of particle i
+         * \param qj Charge of particle j
+         */
+        DEVICE void setCharge(Scalar qi, Scalar qj) {}
+
+        //! Base potential does not need shape
+        DEVICE static bool needsShape()
+            {
+            return false;
+            }
+
+        //! Accept the optional shape values
+        /*!
+         * \param shapei Shape of particle i
+         * \param shapej Shape of particle j
+         */
+        DEVICE void setShape(const shape_param_type *shapei, const shape_param_type *shapej) {}
+
+        //! Base potential does not need tags
+        DEVICE static bool needsTags()
+            {
+            return false;
+            }
+
+        //! Accept the optional tags
+        /*!
+         * \param tagi Tag of particle i
+         * \param tagj Tag of particle j
+         */
+        DEVICE void setTags(unsigned int tagi, unsigned int tagj) {}
+
+        //! Evaluate the force and energy
+        /*! \param force Output parameter to write the computed force.
+         *  \param pair_eng Output parameter to write the computed pair energy.
+         *  \param energy_shift If true, the potential must be shifted so that V(r) is continuous at the cutoff.
+         *  \param torque_i The torque exterted on the i^th particle.
+         *  \param torque_j The torque exterted on the j^th particle.
+         *
+         *  \returns True if they are evaluated or false if they are not because we are beyond the cutoff.
+        */
+        DEVICE bool evaluate(Scalar3& force,
+                             Scalar& pair_eng,
+                             bool energy_shift,
+                             Scalar3& torque_i,
+                             Scalar3& torque_j)
+            {
+            return false;
+            }
+
+    #ifndef NVCC
+        static std::string getName()
+            {
+            throw std::runtime_error("Name not defined for this pair potential.");
+            }
+
+        std::string getShapeSpec() const
+            {
+            throw std::runtime_error("Shape definition not supported for this pair potential.");
+            }
+    #endif // NVCC
+
+    protected:
+        Scalar3 dr;       //!< Stored dr from the constructor
+        Scalar rcutsq;    //!< Stored rcutsq from the constructor
+        Scalar4 quat_i;   //!< Orientation quaternion for particle i
+        Scalar4 quat_j;   //!< Orientation quaternion for particle j
+    };
+
+} // end namespace detail
+} // end namespace azplugins
+
+#undef DEVICE
+#undef HOSTDEVICE
+
+#endif // AZPLUGINS_ANISO_PAIR_EVALUATOR_H_

--- a/azplugins/AnisoPairEvaluatorTwoPatchMorse.h
+++ b/azplugins/AnisoPairEvaluatorTwoPatchMorse.h
@@ -4,16 +4,14 @@
 // Maintainer: wes_reinhart
 
 /*!
- * \file PairEvaluatorTwoPatchMorse.h
+ * \file AnisoPairEvaluatorTwoPatchMorse.h
  * \brief Defines the aniostropic pair force evaluator class for Two-patch Morse potential
  */
 
 #ifndef AZPLUGINS_ANISO_PAIR_EVALUATOR_TWO_PATCH_MORSE_H_
 #define AZPLUGINS_ANISO_PAIR_EVALUATOR_TWO_PATCH_MORSE_H_
 
-#ifndef NVCC
-#include <string>
-#endif
+#include "AnisoPairEvaluator.h"
 
 #include "hoomd/VectorMath.h"
 
@@ -34,7 +32,7 @@ namespace detail
 /*!
  * \sa AnisoPairEvaluatorTwoPatchMorse
  */
-struct two_patch_morse_params
+struct two_patch_morse_params : public AnisoPairParams
     {
     Scalar Mdeps;     //<! Controls the well depth
     Scalar Mrinv;     //<! Controls the well steepness
@@ -95,11 +93,12 @@ HOSTDEVICE inline two_patch_morse_params make_two_patch_morse_params(Scalar Mdep
  * - \a alpha
  * - \a repulsion
  */
-class AnisoPairEvaluatorTwoPatchMorse
+class AnisoPairEvaluatorTwoPatchMorse : public AnisoPairEvaluator
     {
     public:
         //! Define the parameter type used by this pair potential evaluator
         typedef two_patch_morse_params param_type;
+        typedef AnisoPairEvaluator::shape_param_type shape_param_type;
 
         //! Constructor
         /*!
@@ -117,37 +116,11 @@ class AnisoPairEvaluatorTwoPatchMorse
                                                Scalar4& _quat_j,
                                                Scalar _rcutsq,
                                                const param_type& _params)
-            : dr(_dr), rcutsq(_rcutsq), quat_i(_quat_i), quat_j(_quat_j),
+            : AnisoPairEvaluator(_dr, _quat_i, _quat_j, _rcutsq),
               Mdeps(_params.Mdeps), Mrinv(_params.Mrinv), req(_params.req),
               omega(_params.omega), alpha(_params.alpha), repulsion(_params.repulsion)
             {
             }
-
-        //! Two-patch Morse potential does not need diameter
-        DEVICE static bool needsDiameter()
-            {
-            return false;
-            }
-
-        //! Accept the optional diameter values
-        /*!
-         * \param di Diameter of particle i
-         * \param dj Diameter of particle j
-         */
-        DEVICE void setDiameter(Scalar di, Scalar dj){}
-
-        //! Two-patch Morse potential does not need charge
-        DEVICE static bool needsCharge()
-            {
-            return false;
-            }
-
-        //! Accept the optional charge values
-        /*!
-         * \param qi Charge of particle i
-         * \param qj Charge of particle j
-         */
-        DEVICE void setCharge(Scalar qi, Scalar qj){}
 
         //! Evaluate the force and energy
         /*! \param force Output parameter to write the computed force.
@@ -259,10 +232,6 @@ class AnisoPairEvaluatorTwoPatchMorse
         #endif
 
     protected:
-        Scalar3 dr;       //!< Stored dr from the constructor
-        Scalar rcutsq;    //!< Stored rcutsq from the constructor
-        Scalar4 quat_i;   //!< Orientation quaternion for particle i
-        Scalar4 quat_j;   //!< Orientation quaternion for particle j
         Scalar Mdeps;     //<! Controls the well depth
         Scalar Mrinv;     //<! Controls the well steepness
         Scalar req;       //<! Controls the well position

--- a/azplugins/AnisoPairPotentialTwoPatchMorse.cu
+++ b/azplugins/AnisoPairPotentialTwoPatchMorse.cu
@@ -1,15 +1,7 @@
 // Copyright (c) 2018-2019, Michael P. Howard
 // This file is part of the azplugins project, released under the Modified BSD License.
 
-// Maintainer: mphoward / Everyone is free to add additional potentials
-
-/*!
- * \file AnisoPairPotentials.cu
- * \brief Defines the driver functions for computing pair forces on the GPU
- *
- * Each pair potential evaluator needs to have an explicit instantiation of the
- * compute_aniso_pair_potential.
- */
+// Maintainer: mphoward
 
 #include "AnisoPairPotentials.cuh"
 
@@ -21,7 +13,11 @@ namespace gpu
 //! Kernel driver for Two-patch Morse anisotropic pair potential
 template cudaError_t compute_aniso_pair_potential<azplugins::detail::AnisoPairEvaluatorTwoPatchMorse>
     (const a_pair_args_t& pair_args,
-     const typename azplugins::detail::AnisoPairEvaluatorTwoPatchMorse::param_type *d_params);
+     const typename azplugins::detail::AnisoPairEvaluatorTwoPatchMorse::param_type*
+     #ifdef HOOMD_MD_ANISO_SHAPE_PARAM
+     , const typename azplugins::detail::AnisoPairEvaluatorTwoPatchMorse::shape_param_type*
+     #endif
+    );
 
 } // end namespace gpu
 } // end namespace azplugins

--- a/azplugins/AnisoPairPotentials.cuh
+++ b/azplugins/AnisoPairPotentials.cuh
@@ -16,6 +16,7 @@
 
 #include "hoomd/md/AnisoPotentialPairGPU.cuh"
 #include "AnisoPairPotentials.h"
+#include "HOOMDAPI.h"
 
 namespace azplugins
 {
@@ -28,7 +29,12 @@ namespace gpu
  * \tparam evaluator Evaluator functor
  */
 template<class evaluator>
-cudaError_t compute_aniso_pair_potential(const a_pair_args_t& pair_args, const typename evaluator::param_type *d_params);
+cudaError_t compute_aniso_pair_potential(const a_pair_args_t& pair_args,
+                                         const typename evaluator::param_type *d_params
+                                         #ifdef HOOMD_MD_ANISO_SHAPE_PARAM
+                                         , const typename evaluator::shape_param_type *d_shape_params
+                                         #endif
+                                         );
 
 #ifdef NVCC
 /*!
@@ -36,9 +42,19 @@ cudaError_t compute_aniso_pair_potential(const a_pair_args_t& pair_args, const t
  * must be specifically instantiated per potential in a cu file.
  */
 template<class evaluator>
-cudaError_t compute_aniso_pair_potential(const a_pair_args_t& pair_args, const typename evaluator::param_type *d_params)
+cudaError_t compute_aniso_pair_potential(const a_pair_args_t& pair_args,
+                                         const typename evaluator::param_type *d_params
+                                         #ifdef HOOMD_MD_ANISO_SHAPE_PARAM
+                                         , const typename evaluator::shape_param_type *d_shape_params
+                                         #endif
+                                         )
     {
-    return ::gpu_compute_pair_aniso_forces<evaluator>(pair_args, d_params);
+    return ::gpu_compute_pair_aniso_forces<evaluator>(pair_args,
+                                                      d_params
+                                                      #ifdef HOOMD_MD_ANISO_SHAPE_PARAM
+                                                      , d_shape_params
+                                                      #endif
+                                                      );
     }
 #endif
 } // end namespace gpu

--- a/azplugins/CMakeLists.txt
+++ b/azplugins/CMakeLists.txt
@@ -65,10 +65,10 @@ endif(ENABLE_CUDA)
 
 # cuda cu source files
 set(_${COMPONENT_NAME}_cu_sources
-    AnisoPairPotentials.cu
+    AnisoPairPotentialTwoPatchMorse.cu
     BondPotentials.cu
     BounceBackNVEGPU.cu
-    DPDPotentials.cu
+    DPDPotentialGeneralWeight.cu
     ImplicitDropletEvaporatorGPU.cu
     ImplicitPlaneEvaporatorGPU.cu
     OrientationRestraintComputeGPU.cu

--- a/azplugins/DPDEvaluatorGeneralWeight.h
+++ b/azplugins/DPDEvaluatorGeneralWeight.h
@@ -11,6 +11,8 @@
 #ifndef AZPLUGINS_DPD_EVALUATOR_GENERAL_WEIGHT_H_
 #define AZPLUGINS_DPD_EVALUATOR_GENERAL_WEIGHT_H_
 
+#include "PairEvaluator.h"
+
 #include "hoomd/HOOMDMath.h"
 #include "hoomd/RandomNumbers.h"
 #include "RNGIdentifiers.h"
@@ -54,7 +56,7 @@ namespace detail
  *
  * where \a s is usually 2 for the "standard" DPD method. Refer to the original paper for more details.
  */
-class DPDEvaluatorGeneralWeight
+class DPDEvaluatorGeneralWeight : public PairEvaluator
     {
     public:
         //! Three parameters are used by this DPD potential evaluator
@@ -67,7 +69,7 @@ class DPDEvaluatorGeneralWeight
          * \param _params Per type pair parameters of this potential
          */
         DEVICE DPDEvaluatorGeneralWeight(Scalar _rsq, Scalar _rcutsq, const param_type& _params)
-            : rsq(_rsq), rcutsq(_rcutsq), a(_params.x), gamma(_params.y), s(_params.z)
+            : PairEvaluator(_rsq,_rcutsq), a(_params.x), gamma(_params.y), s(_params.z)
             {
             }
 
@@ -112,24 +114,6 @@ class DPDEvaluatorGeneralWeight
             {
             m_T = Temp;
             }
-
-        //! DPD does not use diameter
-        DEVICE static bool needsDiameter() { return false; }
-        //! Accept the optional diameter values
-        /*!
-         * \param di Diameter of particle i
-         * \param dj Diameter of particle j
-         */
-        DEVICE void setDiameter(Scalar di, Scalar dj) { }
-
-        //! DPD doesn't use charge
-        DEVICE static bool needsCharge() { return false; }
-        //! Accept the optional diameter values
-        /*!
-         * \param qi Charge of particle i
-         * \param qj Charge of particle j
-         */
-        DEVICE void setCharge(Scalar qi, Scalar qj) { }
 
         //! Evaluate the force and energy using the conservative force only
         /*!
@@ -231,9 +215,6 @@ class DPDEvaluatorGeneralWeight
         #endif
 
     protected:
-        Scalar rsq;             //!< Squared distance between particles
-        Scalar rcutsq;          //!< Squared cutoff between particles
-
         Scalar a;               //!< Strength of repulsion
         Scalar gamma;           //!< Drag term
         Scalar s;               //!< Exponent for the dissipative weight function

--- a/azplugins/DPDPotentialGeneralWeight.cu
+++ b/azplugins/DPDPotentialGeneralWeight.cu
@@ -1,15 +1,7 @@
 // Copyright (c) 2018-2019, Michael P. Howard
 // This file is part of the azplugins project, released under the Modified BSD License.
 
-// Maintainer: mphoward / Everyone is free to add additional potentials
-
-/*!
- * \file DPDPotentials.cu
- * \brief Defines the driver functions for computing DPD forces on the GPU
- *
- * Each DPD potential evaluator needs to have an explicit instantiation of the
- * compute_dpd_potential.
- */
+// Maintainer: mphoward
 
 #include "DPDPotentials.cuh"
 

--- a/azplugins/HOOMDAPI.h
+++ b/azplugins/HOOMDAPI.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file HOOMDAPI.h
+ * \brief Defines information about the HOOMD API that is version dependent
+ */
+
+#ifndef AZPLUGINS_HOOMD_API_H_
+#define AZPLUGINS_HOOMD_API_H_
+
+#include "HOOMDVersion.h"
+
+#if (HOOMD_VERSION_MAJOR >= 2)
+
+#if (HOOMD_VERSION_MINOR >= 8)
+// anisotropic pair potential evaluators require an additional shape parameter
+#define HOOMD_MD_ANISO_SHAPE_PARAM
+#endif // 2.8
+
+#endif // 2.x
+
+#endif // AZPLUGINS_HOOMD_API_H_

--- a/azplugins/PairEvaluator.h
+++ b/azplugins/PairEvaluator.h
@@ -1,0 +1,113 @@
+// Copyright (c) 2018-2019, Michael P. Howard
+// This file is part of the azplugins project, released under the Modified BSD License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file PairEvaluator.h
+ * \brief Base class for pair evaluators.
+ */
+
+#ifndef AZPLUGINS_PAIR_EVALUATOR_H_
+#define AZPLUGINS_PAIR_EVALUATOR_H_
+
+#include "hoomd/HOOMDMath.h"
+
+#ifdef NVCC
+#define DEVICE __device__
+#else
+#define DEVICE
+#include <string>
+#endif
+
+namespace azplugins
+{
+namespace detail
+{
+
+//! Base class for isotropic pair potential evaluator
+/*!
+ * This class covers the default case of a simple potential that doesn't require
+ * additional data. Its constructor stores the common variables. The class can
+ * be overridden for more complex potentials.
+ *
+ * Deriving classes \b must define a \a param_type . They must also
+ * give the potential a name and implement the evaluate() method.
+ */
+class PairEvaluator
+    {
+    public:
+        DEVICE PairEvaluator(const Scalar _rsq,
+                             const Scalar _rcutsq)
+        : rsq(_rsq), rcutsq(_rcutsq)
+        {}
+
+        //! Base potential does not need diameter
+        DEVICE static bool needsDiameter()
+            {
+            return false;
+            }
+
+        //! Accept the optional diameter values
+        /*!
+         * \param di Diameter of particle i
+         * \param dj Diameter of particle j
+         */
+        DEVICE void setDiameter(Scalar di, Scalar dj) {}
+
+        //! Base potential does not need charge
+        DEVICE static bool needsCharge()
+            {
+            return false;
+            }
+
+        //! Accept the optional charge values
+        /*!
+         * \param qi Charge of particle i
+         * \param qj Charge of particle j
+         */
+        DEVICE void setCharge(Scalar qi, Scalar qj) {}
+
+        //! Evaluate the force and energy
+        /*!
+         * \param force_divr Holds the computed force divided by r
+         * \param pair_eng Holds the computed pair energy
+         * \param energy_shift If true, the potential is shifted to zero at the cutoff
+         *
+         * \returns True if the energy calculation occurs
+         *
+         * The calculation does not occur if the pair distance is greater than the cutoff
+         * or if the potential is scaled to zero.
+         */
+        DEVICE bool evalForceAndEnergy(Scalar& force_divr, Scalar& pair_eng, bool energy_shift)
+            {
+            return false;
+            }
+
+    #ifndef NVCC
+        //! Get the name of this potential
+        /*!
+         * This method must be overridden by deriving classes.
+         */
+        static std::string getName()
+            {
+            throw std::runtime_error("Name not defined for this pair potential.");
+            }
+
+        std::string getShapeSpec() const
+            {
+            throw std::runtime_error("Shape definition not supported for this pair potential.");
+            }
+    #endif // NVCC
+
+    protected:
+        Scalar rsq;     //!< Squared distance between particles
+        Scalar rcutsq;  //!< Squared cutoff distance
+    };
+
+} // end namespace detail
+} // end namespace azplugins
+
+#undef DEVICE
+
+#endif // AZPLUGINS_PAIR_EVALUATOR_H_

--- a/azplugins/PairEvaluatorAshbaugh.h
+++ b/azplugins/PairEvaluatorAshbaugh.h
@@ -11,11 +11,7 @@
 #ifndef AZPLUGINS_PAIR_EVALUATOR_ASHBAUGH_H_
 #define AZPLUGINS_PAIR_EVALUATOR_ASHBAUGH_H_
 
-#ifndef NVCC
-#include <string>
-#endif
-
-#include "hoomd/HOOMDMath.h"
+#include "PairEvaluator.h"
 
 #ifdef NVCC
 #define DEVICE __device__
@@ -81,7 +77,7 @@ HOSTDEVICE inline ashbaugh_params make_ashbaugh_params(Scalar lj1,
  * - \a rwcasq is the square of the location of the potential minimum (WCA cutoff), pow(2.0/alpha,1./3.) * sigma * sigma
  * - \a wca_shift is the amount needed to shift the energy of the repulsive part to match the attractive energy.
  */
-class PairEvaluatorAshbaugh
+class PairEvaluatorAshbaugh : public PairEvaluator
     {
     public:
         //! Define the parameter type used by this pair potential evaluator
@@ -96,28 +92,9 @@ class PairEvaluatorAshbaugh
          * The functor initializes its members from \a _params.
          */
         DEVICE PairEvaluatorAshbaugh(Scalar _rsq, Scalar _rcutsq, const param_type& _params)
-            : rsq(_rsq), rcutsq(_rcutsq), lj1(_params.lj1), lj2(_params.lj2), lambda(_params.lambda),
+            : PairEvaluator(_rsq, _rcutsq), lj1(_params.lj1), lj2(_params.lj2), lambda(_params.lambda),
               rwcasq(_params.rwcasq), wca_shift(_params.wca_shift)
-            {
-            }
-
-        //! Ashbaugh-Hatch potential does not need diameter
-        DEVICE static bool needsDiameter() { return false; }
-        //! Accept the optional diameter values
-        /*!
-         * \param di Diameter of particle i
-         * \param dj Diameter of particle j
-         */
-        DEVICE void setDiameter(Scalar di, Scalar dj) { }
-
-        //! Ashbaugh-Hatch potential does not need charge
-        DEVICE static bool needsCharge() { return false; }
-        //! Accept the optional charge values
-        /*!
-         * \param qi Charge of particle i
-         * \param qj Charge of particle j
-         */
-        DEVICE void setCharge(Scalar qi, Scalar qj) { }
+            {}
 
         //! Evaluate the force and energy
         /*!
@@ -170,8 +147,6 @@ class PairEvaluatorAshbaugh
         #endif
 
     protected:
-        Scalar rsq;     //!< Stored rsq from the constructor
-        Scalar rcutsq;  //!< Stored rcutsq from the constructor
         Scalar lj1;     //!< lj1 parameter extracted from the params passed to the constructor
         Scalar lj2;     //!< lj2 parameter extracted from the params passed to the constructor
         Scalar lambda;  //!< lambda parameter

--- a/azplugins/PairEvaluatorAshbaugh24.h
+++ b/azplugins/PairEvaluatorAshbaugh24.h
@@ -11,18 +11,12 @@
 #ifndef AZPLUGINS_PAIR_EVALUATOR_ASHBAUGH24_H_
 #define AZPLUGINS_PAIR_EVALUATOR_ASHBAUGH24_H_
 
-#ifndef NVCC
-#include <string>
-#endif
-
-#include "hoomd/HOOMDMath.h"
 #include "PairEvaluatorAshbaugh.h"
+
 #ifdef NVCC
 #define DEVICE __device__
-#define HOSTDEVICE __host__ __device__
 #else
 #define DEVICE
-#define HOSTDEVICE
 #endif
 
 namespace azplugins
@@ -65,7 +59,7 @@ namespace detail
  *
  * Here, WCA means the repulsive part of the Lennard-Jones 48-24 potential.
  */
-class PairEvaluatorAshbaugh24
+class PairEvaluatorAshbaugh24 : public PairEvaluatorAshbaugh
     {
     public:
         //! Define the parameter type used by this pair potential evaluator
@@ -80,28 +74,8 @@ class PairEvaluatorAshbaugh24
          * The functor initializes its members from \a _params.
          */
         DEVICE PairEvaluatorAshbaugh24(Scalar _rsq, Scalar _rcutsq, const param_type& _params)
-          : rsq(_rsq), rcutsq(_rcutsq),lj1(_params.lj1), lj2(_params.lj2), lambda(_params.lambda),
-              rwcasq(_params.rwcasq), wca_shift(_params.wca_shift)
-            {
-            }
-
-        //! LJ 48-24 potential does not need diameter
-        DEVICE static bool needsDiameter() { return false; }
-        //! Accept the optional diameter values
-        /*!
-         * \param di Diameter of particle i
-         * \param dj Diameter of particle j
-         */
-        DEVICE void setDiameter(Scalar di, Scalar dj) { }
-
-        //! LJ 48-24 potential does not need charge
-        DEVICE static bool needsCharge() { return false; }
-        //! Accept the optional charge values
-        /*!
-         * \param qi Charge of particle i
-         * \param qj Charge of particle j
-         */
-        DEVICE void setCharge(Scalar qi, Scalar qj) { }
+          : PairEvaluatorAshbaugh(_rsq,_rcutsq,_params)
+            {}
 
         //! Evaluate the force and energy
         /*!
@@ -158,21 +132,11 @@ class PairEvaluatorAshbaugh24
             return std::string("ashbaugh24");
             }
         #endif
-
-    protected:
-        Scalar rsq;     //!< Stored rsq from the constructor
-        Scalar rcutsq;  //!< Stored rcutsq from the constructor
-        Scalar lj1;     //!< lj1 parameter extracted from the params passed to the constructor
-        Scalar lj2;     //!< lj2 parameter extracted from the params passed to the constructor
-        Scalar lambda;  //!< lambda parameter
-        Scalar rwcasq;  //!< WCA cutoff radius squared
-        Scalar wca_shift; //!< Energy shift for WCA part of the potential
     };
 
 } // end namespace detail
 } // end namespace azplugins
 
 #undef DEVICE
-#undef HOSTDEVICE
 
 #endif // AZPLUGINS_PAIR_EVALUATOR_ASHBAUGH24_H_

--- a/azplugins/PairEvaluatorColloid.h
+++ b/azplugins/PairEvaluatorColloid.h
@@ -11,11 +11,7 @@
 #ifndef AZPLUGINS_PAIR_EVALUATOR_COLLOID_H_
 #define AZPLUGINS_PAIR_EVALUATOR_COLLOID_H_
 
-#ifndef NVCC
-#include <string>
-#endif
-
-#include "hoomd/HOOMDMath.h"
+#include "PairEvaluator.h"
 
 #ifdef NVCC
 #define DEVICE __device__
@@ -64,7 +60,7 @@ namespace detail
  * - \a sigma_6 - \f$\sigma^6\f$
  * - \a form - the style of the pair interaction as in int that is cast to the interaction_type
  */
-class PairEvaluatorColloid
+class PairEvaluatorColloid : public PairEvaluator
     {
     public:
         //! Define the parameter type used by this pair potential evaluator
@@ -82,7 +78,7 @@ class PairEvaluatorColloid
          * The functor initializes its members from \a _params.
          */
         DEVICE PairEvaluatorColloid(Scalar _rsq, Scalar _rcutsq, const param_type& _params)
-            : rsq(_rsq), rcutsq(_rcutsq)
+            : PairEvaluator(_rsq,_rcutsq)
             {
             A = _params.x;
             sigma_3 = _params.y;
@@ -104,15 +100,6 @@ class PairEvaluatorColloid
             ai = Scalar(0.5) * di;
             aj = Scalar(0.5) * dj;
             }
-
-        //! Colloid potential does not need charge
-        DEVICE static bool needsCharge() { return false; }
-        //! Accept the optional charge values
-        /*!
-         * \param qi Charge of particle i
-         * \param qj Charge of particle j
-         */
-        DEVICE void setCharge(Scalar qi, Scalar qj) { }
 
         //! Computes the solvent-solvent interaction
         /*!
@@ -300,9 +287,6 @@ class PairEvaluatorColloid
         #endif
 
     protected:
-        Scalar rsq;     //!< Stored rsq from the constructor
-        Scalar rcutsq;  //!< Stored rcutsq from the constructor
-
         Scalar A;       //!< Hamaker constant
         Scalar sigma_3; //!< Sigma^3
         Scalar sigma_6; //!< Sigma^6

--- a/azplugins/PairEvaluatorLJ124.h
+++ b/azplugins/PairEvaluatorLJ124.h
@@ -11,11 +11,7 @@
 #ifndef AZPLUGINS_PAIR_EVALUATOR_LJ124_H_
 #define AZPLUGINS_PAIR_EVALUATOR_LJ124_H_
 
-#ifndef NVCC
-#include <string>
-#endif
-
-#include "hoomd/HOOMDMath.h"
+#include "PairEvaluator.h"
 
 #ifdef NVCC
 #define DEVICE __device__
@@ -44,7 +40,7 @@ namespace detail
  * - \a lj1 = 1.5 * sqrt(3.0) * epsilon * pow(sigma,12.0)
  * - \a lj2 = alpha * 1.5 * sqrt(3.0) * epsilon * pow(sigma,4.0);
  */
-class PairEvaluatorLJ124
+class PairEvaluatorLJ124 : public PairEvaluator
     {
     public:
         //! Define the parameter type used by this pair potential evaluator
@@ -59,25 +55,8 @@ class PairEvaluatorLJ124
          * The functor initializes its members from \a _params.
          */
         DEVICE PairEvaluatorLJ124(Scalar _rsq, Scalar _rcutsq, const param_type& _params)
-          : rsq(_rsq), rcutsq(_rcutsq), lj1(_params.x), lj2(_params.y) { }
-
-        //! LJ 12-4 potential does not need diameter
-        DEVICE static bool needsDiameter() { return false; }
-        //! Accept the optional diameter values
-        /*!
-         * \param di Diameter of particle i
-         * \param dj Diameter of particle j
-         */
-        DEVICE void setDiameter(Scalar di, Scalar dj) { }
-
-        //! LJ 12-4 potential does not need charge
-        DEVICE static bool needsCharge() { return false; }
-        //! Accept the optional charge values
-        /*!
-         * \param qi Charge of particle i
-         * \param qj Charge of particle j
-         */
-        DEVICE void setCharge(Scalar qi, Scalar qj) { }
+          : PairEvaluator(_rsq,_rcutsq), lj1(_params.x), lj2(_params.y)
+          {}
 
         //! Evaluate the force and energy
         /*!
@@ -123,8 +102,6 @@ class PairEvaluatorLJ124
         #endif
 
     protected:
-        Scalar rsq;     //!< Stored rsq from the constructor
-        Scalar rcutsq;  //!< Stored rcutsq from the constructor
         Scalar lj1;     //!< lj1 parameter extracted from the params passed to the constructor
         Scalar lj2;     //!< lj2 parameter extracted from the params passed to the constructor
     };

--- a/azplugins/PairEvaluatorLJ96.h
+++ b/azplugins/PairEvaluatorLJ96.h
@@ -11,11 +11,7 @@
 #ifndef AZPLUGINS_PAIR_EVALUATOR_LJ96_H_
 #define AZPLUGINS_PAIR_EVALUATOR_LJ96_H_
 
-#ifndef NVCC
-#include <string>
-#endif
-
-#include "hoomd/HOOMDMath.h"
+#include "PairEvaluator.h"
 
 #ifdef NVCC
 #define DEVICE __device__
@@ -44,7 +40,7 @@ namespace detail
  * - \a lj1 = 27 / 4 * epsilon * pow(sigma,9.0)
  * - \a lj2 = alpha * 27 / 4 * epsilon * pow(sigma,6.0);
  */
-class PairEvaluatorLJ96
+class PairEvaluatorLJ96 : public PairEvaluator
     {
     public:
         //! Define the parameter type used by this pair potential evaluator
@@ -59,25 +55,8 @@ class PairEvaluatorLJ96
          * The functor initializes its members from \a _params.
          */
         DEVICE PairEvaluatorLJ96(Scalar _rsq, Scalar _rcutsq, const param_type& _params)
-          : rsq(_rsq), rcutsq(_rcutsq), lj1(_params.x), lj2(_params.y) { }
-
-        //! LJ 9-6 potential does not need diameter
-        DEVICE static bool needsDiameter() { return false; }
-        //! Accept the optional diameter values
-        /*!
-         * \param di Diameter of particle i
-         * \param dj Diameter of particle j
-         */
-        DEVICE void setDiameter(Scalar di, Scalar dj) { }
-
-        //! LJ 9-6 potential does not need charge
-        DEVICE static bool needsCharge() { return false; }
-        //! Accept the optional charge values
-        /*!
-         * \param qi Charge of particle i
-         * \param qj Charge of particle j
-         */
-        DEVICE void setCharge(Scalar qi, Scalar qj) { }
+          : PairEvaluator(_rsq,_rcutsq), lj1(_params.x), lj2(_params.y)
+          {}
 
         //! Evaluate the force and energy
         /*!
@@ -123,8 +102,6 @@ class PairEvaluatorLJ96
         #endif
 
     protected:
-        Scalar rsq;     //!< Stored rsq from the constructor
-        Scalar rcutsq;  //!< Stored rcutsq from the constructor
         Scalar lj1;     //!< lj1 parameter extracted from the params passed to the constructor
         Scalar lj2;     //!< lj2 parameter extracted from the params passed to the constructor
     };

--- a/azplugins/PairEvaluatorShiftedLJ.h
+++ b/azplugins/PairEvaluatorShiftedLJ.h
@@ -11,11 +11,7 @@
 #ifndef AZPLUGINS_PAIR_EVALUATOR_SHIFTED_LJ_H_
 #define AZPLUGINS_PAIR_EVALUATOR_SHIFTED_LJ_H_
 
-#ifndef NVCC
-#include <string>
-#endif
-
-#include "hoomd/HOOMDMath.h"
+#include "PairEvaluator.h"
 
 #ifdef NVCC
 #define DEVICE __device__
@@ -49,7 +45,7 @@ namespace detail
  * - \a lj2 = alpha * 4.0 * epsilon * pow(sigma,6.0);
  * - \a Delta is the amount to shift the potential minimum by.
  */
-class PairEvaluatorShiftedLJ
+class PairEvaluatorShiftedLJ : public PairEvaluator
     {
     public:
         //! Define the parameter type used by this pair potential evaluator
@@ -64,26 +60,8 @@ class PairEvaluatorShiftedLJ
          * The functor initializes its members from \a _params.
          */
         DEVICE PairEvaluatorShiftedLJ(Scalar _rsq, Scalar _rcutsq, const param_type& _params)
-            : rsq(_rsq), rcutsq(_rcutsq), lj1(_params.x), lj2(_params.y), delta(_params.z)
-            { }
-
-        //! Shifted Lennard-Jones potential does not need diameter
-        DEVICE static bool needsDiameter() { return false; }
-        //! Accept the optional diameter values
-        /*!
-         * \param di Diameter of particle i
-         * \param dj Diameter of particle j
-         */
-        DEVICE void setDiameter(Scalar di, Scalar dj) { }
-
-        //! Shifted Lennard-Jones potential does not need charge
-        DEVICE static bool needsCharge() { return false; }
-        //! Accept the optional charge values
-        /*!
-         * \param qi Charge of particle i
-         * \param qj Charge of particle j
-         */
-        DEVICE void setCharge(Scalar qi, Scalar qj) { }
+            : PairEvaluator(_rsq,_rcutsq), lj1(_params.x), lj2(_params.y), delta(_params.z)
+            {}
 
         //! Evaluate the force and energy
         /*!
@@ -142,8 +120,6 @@ class PairEvaluatorShiftedLJ
         #endif
 
     protected:
-        Scalar rsq;     //!< Stored rsq from the constructor
-        Scalar rcutsq;  //!< Stored rcutsq from the constructor
         Scalar lj1;     //!< lj1 parameter extracted from the params passed to the constructor
         Scalar lj2;     //!< lj2 parameter extracted from the params passed to the constructor
         Scalar delta;   //!< shift parameter

--- a/azplugins/PairEvaluatorSpline.h
+++ b/azplugins/PairEvaluatorSpline.h
@@ -11,11 +11,7 @@
 #ifndef AZPLUGINS_PAIR_EVALUATOR_SPLINE_H_
 #define AZPLUGINS_PAIR_EVALUATOR_SPLINE_H_
 
-#ifndef NVCC
-#include <string>
-#endif
-
-#include "hoomd/HOOMDMath.h"
+#include "PairEvaluator.h"
 
 #ifdef NVCC
 #define DEVICE __device__
@@ -41,7 +37,7 @@ namespace detail
  * The three  needed parameters are specified and stored in a
  * Scalar3.
  */
-class PairEvaluatorSpline
+class PairEvaluatorSpline : public PairEvaluator
     {
     public:
         //! Define the parameter type used by this pair potential evaluator
@@ -56,26 +52,8 @@ class PairEvaluatorSpline
          * The functor initializes its members from \a _params.
          */
         DEVICE PairEvaluatorSpline(Scalar _rsq, Scalar _rcutsq, const param_type& _params)
-            : rsq(_rsq), rcutsq(_rcutsq), a(_params.x), m(_params.y), ron_sq(_params.z)
-            { }
-
-        //! Spline pair potential does not need diameter
-        DEVICE static bool needsDiameter() { return false; }
-        //! Accept the optional diameter values
-        /*!
-         * \param di Diameter of particle i
-         * \param dj Diameter of particle j
-         */
-        DEVICE void setDiameter(Scalar di, Scalar dj) { }
-
-        //! Spline pair potential does not need charge
-        DEVICE static bool needsCharge() { return false; }
-        //! Accept the optional charge values
-        /*!
-         * \param qi Charge of particle i
-         * \param qj Charge of particle j
-         */
-        DEVICE void setCharge(Scalar qi, Scalar qj) { }
+            : PairEvaluator(_rsq,_rcutsq), a(_params.x), m(_params.y), ron_sq(_params.z)
+            {}
 
         //! Evaluate the force and energy
         /*!
@@ -121,8 +99,6 @@ class PairEvaluatorSpline
         #endif
 
     protected:
-        Scalar rsq;     //!< Stored rsq from the constructor
-        Scalar rcutsq;  //!< Stored rcutsq from the constructor
         Scalar a;     //!< a - amplitude parameter extracted from the params passed to the constructor
         Scalar m;     //!< m - exponent parameter extracted from the params passed to the constructor
         Scalar ron_sq;    //!< r_on**2 - squared distance for where the potential reaches the plateau value a


### PR DESCRIPTION
* Pair potential evaluators have a base class to simplify updates in future.
* Shape parameters are conditionally supported based on HOOMD version.

`HOOMDAPI.h` moves toward a solution to #10 from the C++ level.

Resolves #18 