### PR TITLE
Instantiate CUDA kernels for ConstantFlow

### DIFF
--- a/azplugins/TwoStepBrownianFlowGPU.cu
+++ b/azplugins/TwoStepBrownianFlowGPU.cu
@@ -15,6 +15,26 @@ namespace azplugins
 {
 namespace gpu
 {
+//! Explicit instantiation of ConstantFlow integrator
+template cudaError_t brownian_flow<azplugins::ConstantFlow>(Scalar4 *d_pos,
+                                                            int3 *d_image,
+                                                            const BoxDim& box,
+                                                            const Scalar4 *d_net_force,
+                                                            const unsigned int *d_tag,
+                                                            const unsigned int *d_group,
+                                                            const Scalar *d_diameter,
+                                                            const Scalar lambda,
+                                                            const Scalar *d_gamma,
+                                                            const unsigned int ntypes,
+                                                            const azplugins::ConstantFlow& flow_field,
+                                                            const unsigned int N,
+                                                            const Scalar dt,
+                                                            const Scalar T,
+                                                            const unsigned int timestep,
+                                                            const unsigned int seed,
+                                                            bool noiseless,
+                                                            bool use_lambda,
+                                                            const unsigned int block_size);
 //! Explicit instantiation of ParabolicFlow integrator
 template cudaError_t brownian_flow<azplugins::ParabolicFlow>(Scalar4 *d_pos,
                                                              int3 *d_image,

--- a/azplugins/TwoStepLangevinFlowGPU.cu
+++ b/azplugins/TwoStepLangevinFlowGPU.cu
@@ -90,6 +90,26 @@ cudaError_t langevin_flow_step1(Scalar4 *d_pos,
     return cudaSuccess;
     }
 
+//! Explicit instantiation of ConstantFlow integrator
+template cudaError_t langevin_flow_step2<azplugins::ConstantFlow>(Scalar4 *d_vel,
+                                                                  Scalar3 *d_accel,
+                                                                  const Scalar4 *d_pos,
+                                                                  const Scalar4 *d_net_force,
+                                                                  const unsigned int *d_tag,
+                                                                  const unsigned int *d_group,
+                                                                  const Scalar *d_diameter,
+                                                                  const Scalar lambda,
+                                                                  const Scalar *d_gamma,
+                                                                  const unsigned int ntypes,
+                                                                  const azplugins::ConstantFlow& flow_field,
+                                                                  const unsigned int N,
+                                                                  const Scalar dt,
+                                                                  const Scalar T,
+                                                                  const unsigned int timestep,
+                                                                  const unsigned int seed,
+                                                                  bool noiseless,
+                                                                  bool use_lambda,
+                                                                  const unsigned int block_size);
 //! Explicit instantiation of ParabolicFlow integrator
 template cudaError_t langevin_flow_step2<azplugins::ParabolicFlow>(Scalar4 *d_vel,
                                                                    Scalar3 *d_accel,


### PR DESCRIPTION
Fixes a compilation issue with v0.9.0 reported by @ara137

```
[ 98%] Linking CXX executable example_test
../_azplugins.cpython-35m-x86_64-linux-gnu.so: undefined reference to 
`cudaError 
azplugins::gpu::brownian_flow<azplugins::ConstantFlow>(double4*, int3*, 
BoxDim const&, double4 const*, unsigned int const*, unsigned int const*, 
double const*, double, double const*, unsigned int, 
azplugins::ConstantFlow const&, unsigned int, double, double, unsigned 
int, unsigned int, bool, bool, unsigned int)'
../_azplugins.cpython-35m-x86_64-linux-gnu.so: undefined reference to 
`cudaError 
azplugins::gpu::langevin_flow_step2<azplugins::ConstantFlow>(double4*, 
double3*, double4 const*, double4 const*, unsigned int const*, unsigned 
int const*, double const*, double, double const*, unsigned int, 
azplugins::ConstantFlow const&, unsigned int, double, double, unsigned 
int, unsigned int, bool, bool, unsigned int)'
collect2: error: ld returned 1 exit status
azplugins/test/CMakeFiles/example_test.dir/build.make:101: recipe for 
target 'azplugins/test/example_test' failed
make[2]: *** [azplugins/test/example_test] Error 1
CMakeFiles/Makefile2:239: recipe for target 
'azplugins/test/CMakeFiles/example_test.dir/all' failed
make[1]: *** [azplugins/test/CMakeFiles/example_test.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2
```

This missing template causes a linker error, as it should. Weirdly, this is not an error in the Ubuntu 18 test container.